### PR TITLE
fix: wire Deepgram BCP-47 language code passthrough

### DIFF
--- a/electron/audio/DeepgramStreamingSTT.ts
+++ b/electron/audio/DeepgramStreamingSTT.ts
@@ -61,6 +61,7 @@ export class DeepgramStreamingSTT extends EventEmitter {
             const config = ENGLISH_VARIANTS[key];
             if (!config) {
                 console.warn(`[DeepgramStreaming] Unknown language key: ${key}`);
+                this.pendingLanguageChange = undefined;
                 return;
             }
 

--- a/electron/audio/DeepgramStreamingSTT.ts
+++ b/electron/audio/DeepgramStreamingSTT.ts
@@ -11,6 +11,7 @@
 
 import { EventEmitter } from 'events';
 import WebSocket from 'ws';
+import { ENGLISH_VARIANTS } from '../config/languages';
 
 const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 30000;
@@ -24,6 +25,9 @@ export class DeepgramStreamingSTT extends EventEmitter {
 
     private sampleRate = 16000;
     private numChannels = 1;
+    private languageCode = 'en-US';
+
+    private pendingLanguageChange?: NodeJS.Timeout;
 
     private reconnectAttempts = 0;
     private reconnectTimer: NodeJS.Timeout | null = null;
@@ -48,8 +52,30 @@ export class DeepgramStreamingSTT extends EventEmitter {
         console.log(`[DeepgramStreaming] Channel count set to ${count}`);
     }
 
-    /** No-op — Deepgram language is auto-detected or set via query param */
-    public setRecognitionLanguage(_key: string): void { }
+    public setRecognitionLanguage(key: string): void {
+        if (this.pendingLanguageChange) {
+            clearTimeout(this.pendingLanguageChange);
+        }
+
+        this.pendingLanguageChange = setTimeout(() => {
+            const config = ENGLISH_VARIANTS[key];
+            if (!config) {
+                console.warn(`[DeepgramStreaming] Unknown language key: ${key}`);
+                return;
+            }
+
+            console.log(`[DeepgramStreaming] Updating recognition language to: ${key} (${config.primary})`);
+            this.languageCode = config.primary;
+
+            if (this.isActive) {
+                console.log('[DeepgramStreaming] Language changed while streaming. Restarting stream...');
+                this.stop();
+                this.start();
+            }
+
+            this.pendingLanguageChange = undefined;
+        }, 250);
+    }
 
     /** No-op — no Google credentials needed */
     public setCredentials(_path: string): void { }
@@ -114,7 +140,8 @@ export class DeepgramStreamingSTT extends EventEmitter {
             `&sample_rate=${this.sampleRate}` +
             `&channels=${this.numChannels}` +
             `&smart_format=true` +
-            `&interim_results=true`;
+            `&interim_results=true` +
+            `&language=${this.languageCode}`;
 
         console.log(`[DeepgramStreaming] Connecting (rate=${this.sampleRate}, ch=${this.numChannels})...`);
 

--- a/electron/audio/GoogleSTT.ts
+++ b/electron/audio/GoogleSTT.ts
@@ -84,6 +84,7 @@ export class GoogleSTT extends EventEmitter {
             const config = ENGLISH_VARIANTS[key];
             if (!config) {
                 console.warn(`[GoogleSTT] Unknown language key: ${key}`);
+                this.pendingLanguageChange = undefined;
                 return;
             }
 

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -927,7 +927,7 @@ export function initializeIpcHandlers(appState: AppState): void {
         // Test Deepgram via WebSocket connection
         const WebSocket = require('ws');
         return await new Promise<{ success: boolean; error?: string }>((resolve) => {
-          const url = 'wss://api.deepgram.com/v1/listen?model=nova-2&encoding=linear16&sample_rate=16000&channels=1';
+          const url = 'wss://api.deepgram.com/v1/listen?model=nova-2&encoding=linear16&sample_rate=16000&channels=1&language=en-US';
           const ws = new WebSocket(url, {
             headers: { Authorization: `Token ${apiKey} ` },
           });


### PR DESCRIPTION
## Summary

`DeepgramStreamingSTT.setRecognitionLanguage()` was a no-op stub — it stored nothing and the WebSocket URL was built without a `language` query parameter. Deepgram always auto-detected the language, ignoring the user's selection. This fix wires the BCP-47 language code through to the Deepgram API, matching the existing GoogleSTT implementation pattern.

## Changes

- **`electron/audio/DeepgramStreamingSTT.ts`** (+31/-3): Added `languageCode` field (default `en-US`) and `pendingLanguageChange` debounce timer. Replaced the empty `setRecognitionLanguage` stub with a full implementation that validates the language key against `ENGLISH_VARIANTS`, logs the change, updates `languageCode`, and restarts the stream if active. Appended `&language=${this.languageCode}` to the WebSocket URL in `connect()`.
- **`electron/ipcHandlers.ts`** (+1/-1): Appended `&language=en-US` to the hardcoded Deepgram test-connection URL so the IPC health-check also uses a language parameter.

## Validation

| Check | Result |
|-------|--------|
| `npx tsc -p electron/tsconfig.json --noEmit` | ✅ Exit 0, no errors |
| `npm run build` | ✅ 3834 modules, compiled in 6.28s |
| Lint / tests | N/A — not configured in project |

Manual verification checklist (requires Deepgram API key):
- [ ] Set STT provider to Deepgram, language to English (India) → console logs `&language=en-IN` in WebSocket URL
- [ ] Change language mid-session → logs `Language changed while streaming. Restarting stream...`
- [ ] Settings → test Deepgram connection → success dialog

## Notes

- Deepgram does not support `alternativeLanguageCodes` (unlike Google STT) — only a single `language` param is used. This is intentional asymmetry.
- The test URL uses a hardcoded `en-US` default — correct, since the test handler doesn't know the user's saved language preference at test time.
- `connect()` reads `this.languageCode` at call time, so reconnections automatically use the current language with no additional wiring.

Fixes #9