### PR TITLE
feat(corpus): local-corpus RAG with indexing, retrieval & freshness guard

### DIFF
--- a/.archon/workflows/cluely-brainstorm-26.yaml
+++ b/.archon/workflows/cluely-brainstorm-26.yaml
@@ -1,0 +1,392 @@
+name: cluely-brainstorm-26
+description: |
+  Brainstorm across all 26 open Cluely_fr GitHub issues against Guillaume's stated
+  goal ("full automation of working workflow: Zoom meetings + calendar + email + KB
+  → validated tasks dispatched from the app"). Evaluates each issue at the same
+  depth, cross-synthesizes to surface composite features, then generates full
+  specs + implementation plans per superpowers format. Emergent ideas queue into
+  a single "proposals" GitHub issue for review.
+
+  Rubric (workflow defaults; per-issue override allowed):
+    - 20% time-to-task  (meeting-end → dispatched job)
+    - 40% context fidelity (in-meeting grounding, KB citations, anti-hallucination)
+    - 40% decision capture (implicit → explicit auditable actions)
+
+provider: claude
+model: sonnet
+
+nodes:
+  # ───────────────────────────────────────────────────────
+  # Layer 0 — gather inputs in parallel
+  # ───────────────────────────────────────────────────────
+  - id: fetch-issues
+    bash: |
+      set -euo pipefail
+      ART="$ARTIFACTS_DIR"
+      mkdir -p "$ART/issues"
+      gh issue list --state open --limit 100 \
+        --json number,title,body,labels,url \
+        > "$ART/issues/all.json"
+      # Split into per-issue files keyed by number for downstream fan-out.
+      ART="$ART" node -e '
+        const fs = require("fs");
+        const path = require("path");
+        const art = process.env.ART;
+        const arr = JSON.parse(fs.readFileSync(path.join(art, "issues", "all.json"), "utf8"));
+        const live = arr.filter(i => !(i.labels || []).some(l => l.name === "wontfix"));
+        for (const i of live) {
+          fs.writeFileSync(
+            path.join(art, "issues", i.number + ".json"),
+            JSON.stringify(i, null, 2)
+          );
+        }
+        fs.writeFileSync(
+          path.join(art, "issues", "INDEX.json"),
+          JSON.stringify(live.map(i => ({number: i.number, title: i.title})), null, 2)
+        );
+        console.log("Live issues: " + live.length);
+      '
+      ls "$ART/issues/" | head -40
+      echo "---FETCHED---"
+    timeout: 60000
+
+  - id: goal-anchor
+    prompt: |
+      You are anchoring the brainstorm. Do NOT evaluate issues. Just produce
+      the rubric that every downstream evaluator will use.
+
+      USER GOAL (verbatim, do not paraphrase away):
+        "Full automation of my working workflow taking zoom meetings as input
+        with calendar, email and knowledge base about my projects as context
+        to design tasks that I can validate and run from the same app. This
+        is the primitive idea but we need to make it robust; add features
+        (hence the brainstorming session)."
+
+      RUBRIC (default weights — override per-issue only when the issue is
+      clearly one-dimensional):
+        - time_to_task: 20%  — meeting-end → dispatched Archon job
+        - context_fidelity: 40% — in-meeting grounding, KB citations,
+                                  anti-hallucination
+        - decision_capture: 40% — implicit decisions → explicit, auditable
+                                  action items
+
+      INFERRED CONSTRAINTS from Guillaume's environment (from memory/CLAUDE.md):
+        - Mac-only desktop app (Electron), Claude Max OAuth subscription
+          (not billed API)
+        - Archon CLI installed + available, runs in worktrees
+        - Multi-tier KB: raw files → wiki → NotebookLM notebook (semantic)
+        - Calendar/email/Zoom integration not yet built
+        - User wants autonomous execution, not more chat UI
+
+      Write $ARTIFACTS_DIR/goal.md with:
+        1. The verbatim goal
+        2. The rubric (weights + definition of each dim)
+        3. 5-10 "success signals" — concrete observable outcomes that, if
+           true at end-of-quarter, would mean the goal is reached
+        4. 3-5 "anti-goals" — things that look like progress but aren't
+
+      End your output with the literal string: GOAL_ANCHORED
+    allowed_tools: [Read, Write, Bash]
+    idle_timeout: 600000
+
+  # ───────────────────────────────────────────────────────
+  # Layer 1 — per-issue evaluation (loop, all 26 at same depth)
+  # ───────────────────────────────────────────────────────
+  - id: evaluate-issues
+    depends_on: [fetch-issues, goal-anchor]
+    idle_timeout: 1200000
+    loop:
+      prompt: |
+        You are the per-issue evaluator for the Cluely-brainstorm-26 workflow.
+
+        FRESH session — no memory of prior iterations. Read state from disk.
+
+        STATE FILES:
+          - $ARTIFACTS_DIR/goal.md                    (rubric + goal)
+          - $ARTIFACTS_DIR/issues/INDEX.json          (list of live issues)
+          - $ARTIFACTS_DIR/issues/<N>.json            (full issue payload)
+          - $ARTIFACTS_DIR/evals/<N>.json             (written when done)
+          - $ARTIFACTS_DIR/evals/.progress            (tracks next issue)
+
+        ALGORITHM:
+          1. Read INDEX.json → get list of issue numbers (ordered).
+          2. Read .progress (or treat as 0 if missing) → next_idx.
+          3. If next_idx >= total: write <promise>ALL_EVALUATED</promise> and stop.
+          4. Otherwise: take issue number = INDEX[next_idx].
+          5. Read $ARTIFACTS_DIR/issues/<N>.json (full issue).
+          6. Read $ARTIFACTS_DIR/goal.md (rubric).
+          7. Evaluate the issue against the rubric. Produce JSON:
+             {
+               "number": <N>,
+               "title": "...",
+               "verdict": "keep" | "reshape" | "drop",
+               "reasoning": "2-4 sentences",
+               "scores": {
+                 "time_to_task": 0-10,
+                 "context_fidelity": 0-10,
+                 "decision_capture": 0-10
+               },
+               "weighted_score": <computed>,
+               "rubric_weights_used": {"time_to_task": 0.2, "context_fidelity": 0.4, "decision_capture": 0.4},
+               "dependencies": [<other issue numbers this depends on>],
+               "enables": [<other issue numbers this unlocks>],
+               "composite_candidates": [<issue numbers that would be stronger if merged>],
+               "emergent_ideas": [
+                 {"title": "...", "one_liner": "...", "why_it_beats_existing": "..."}
+               ],
+               "risk_notes": "anything that could make this fail or backfire"
+             }
+          8. Write to $ARTIFACTS_DIR/evals/<N>.json.
+          9. Write (next_idx + 1) to $ARTIFACTS_DIR/evals/.progress.
+          10. End your turn with the literal string: EVAL_DONE_<N>
+              (replace <N> with the actual issue number).
+
+        RULES:
+          - One issue per iteration. Do not evaluate multiple.
+          - Use Read/Write/Bash only. No web fetches.
+          - Do not file GitHub issues from this loop — emergent_ideas are
+            collected into the JSON for later consolidation.
+          - If the issue is labeled 'wontfix', skip it: write an eval with
+            verdict "drop" and reasoning "labeled wontfix", advance progress.
+
+      until: ALL_EVALUATED
+      max_iterations: 30
+      fresh_context: true
+
+  # ───────────────────────────────────────────────────────
+  # Layer 2 — cross-synthesis
+  # ───────────────────────────────────────────────────────
+  - id: cross-synthesize
+    depends_on: [evaluate-issues]
+    idle_timeout: 900000
+    prompt: |
+      You are the cross-synthesizer. All 26 issues have been evaluated
+      individually. Your job is to find the composites — pairs or trios
+      that together produce stronger features than either alone.
+
+      LOAD:
+        - $ARTIFACTS_DIR/goal.md
+        - $ARTIFACTS_DIR/evals/*.json  (all per-issue evaluations)
+
+      PRODUCE $ARTIFACTS_DIR/synthesis.md with these sections:
+
+      ## Ranked roadmap (top-down by weighted_score × strategic fit)
+        - Table: issue # | title | verdict | weighted_score | rationale
+
+      ## Composite features (NEW — not in original 26)
+        For each composite:
+          - Name
+          - Source issues (2-4 numbers)
+          - Why the fusion beats the parts (1 paragraph)
+          - Rough spec outline (3-5 bullets)
+          - Priority signal (high/med/low) against the rubric
+        Find at least 3 composites. Look for:
+          - issues where `composite_candidates` overlap
+          - issues whose `dependencies`/`enables` chain together
+          - issues that all serve the same rubric dimension weakly but
+            together serve it strongly
+
+      ## Emergent ideas (NEW features surfaced during evaluation)
+        Deduplicate emergent_ideas across all 26 evals. Group similar ideas.
+        Output a list: title | one_liner | source_issue_numbers | fit_score (1-10).
+
+      ## Drop list
+        Issues with verdict=drop — keep short (1 line each, with reason).
+
+      ## Execution sequencing
+        Given dependencies + enables from the evals, propose an order for
+        the keep+reshape set. Group into tranches:
+          - Tranche 1 (unlocks everything else)
+          - Tranche 2 (builds on T1)
+          - Tranche 3 (polish / optional)
+        Each tranche: list of issue#s + composite names.
+
+      End your output with: SYNTHESIS_DONE
+    allowed_tools: [Read, Write, Bash, Glob]
+
+  # ───────────────────────────────────────────────────────
+  # Layer 3 — spec + plan per keep/reshape issue (parallel via loop)
+  # ───────────────────────────────────────────────────────
+  - id: spec-plan-generator
+    depends_on: [cross-synthesize]
+    idle_timeout: 1800000
+    loop:
+      prompt: |
+        You are the spec+plan generator. FRESH session — read state from disk.
+
+        LOAD:
+          - $ARTIFACTS_DIR/goal.md
+          - $ARTIFACTS_DIR/synthesis.md
+          - $ARTIFACTS_DIR/evals/*.json
+          - $ARTIFACTS_DIR/specs/.queue        (list of targets, built on first iteration)
+          - $ARTIFACTS_DIR/specs/.progress     (next index)
+
+        FIRST ITERATION ONLY: build the queue.
+          mkdir -p $ARTIFACTS_DIR/specs
+          If $ARTIFACTS_DIR/specs/.queue doesn't exist:
+            - Parse $ARTIFACTS_DIR/evals/*.json for verdict in {keep, reshape}.
+            - Parse $ARTIFACTS_DIR/synthesis.md for composite features.
+            - Write .queue as JSON array of {type: "issue"|"composite", id: <N>|<name>, title}.
+            - Write .progress = 0.
+
+        EACH ITERATION:
+          1. Read .queue and .progress.
+          2. If progress >= queue length: <promise>ALL_SPECS_DONE</promise>.
+          3. Take queue[progress] → target.
+          4. Produce TWO files for this target:
+             a) $ARTIFACTS_DIR/specs/<slug>-spec.md
+                Structure (scaled to complexity):
+                  # <Title>
+                  ## Problem & goal
+                  ## User story
+                  ## Architecture (2-3 sentences)
+                  ## Components (per-file responsibilities)
+                  ## Data flow
+                  ## Error handling
+                  ## Testing approach
+                  ## Success criteria (measurable, tied to rubric)
+             b) $ARTIFACTS_DIR/specs/<slug>-plan.md
+                Follow superpowers:writing-plans format:
+                  > **For agentic workers:** use superpowers:subagent-driven-development or superpowers:executing-plans
+                  **Goal:** ...
+                  **Architecture:** ...
+                  **Tech Stack:** ...
+                  ### Task N: ...
+                    **Files:** Create/Modify/Test (exact paths)
+                    - [ ] Step 1: Write failing test
+                    - [ ] Step 2: Run test to verify fail
+                    - [ ] Step 3: Minimal impl
+                    - [ ] Step 4: Run test to verify pass
+                    - [ ] Step 5: Commit
+                NO placeholders. Every step has real code or real commands.
+          5. Increment .progress.
+          6. End with: SPEC_DONE_<slug>
+
+        RULES:
+          - Slug format: issue-<N> for GitHub issues, composite-<kebab-name> for composites.
+          - Keep specs bounded: 200-800 words. Plans 500-2500 words. Don't over-engineer.
+          - If target is a composite, spec must reference the source issue numbers.
+          - Use Read/Write/Bash/Glob only.
+
+      until: ALL_SPECS_DONE
+      max_iterations: 35
+      fresh_context: true
+
+  # ───────────────────────────────────────────────────────
+  # Layer 4a — emergent-issue consolidation (parallel with spec gen? no — after synth is enough)
+  # ───────────────────────────────────────────────────────
+  - id: emergent-collector
+    depends_on: [cross-synthesize]
+    idle_timeout: 600000
+    prompt: |
+      You are the emergent-issue collector. Build ONE consolidated GitHub
+      issue body that queues all novel ideas for Guillaume to review and
+      cherry-pick.
+
+      LOAD:
+        - $ARTIFACTS_DIR/goal.md
+        - $ARTIFACTS_DIR/synthesis.md
+        - $ARTIFACTS_DIR/evals/*.json
+
+      PRODUCE $ARTIFACTS_DIR/emergent-proposals.md — the full GitHub issue body:
+
+        # Emergent Proposals from cluely-brainstorm-26
+
+        **Workflow run:** $WORKFLOW_ID
+        **Generated:** <date>
+
+        ## How to use this
+        Each proposal below is a candidate feature/composite not already
+        in the 26-issue backlog. Review, and for each one either:
+          - File as its own issue (copy the block, add labels)
+          - Reject (just ignore)
+          - Merge into an existing issue (comment on that issue with the
+            link to this one)
+
+        ## Composites (from synthesis.md)
+        [One section per composite, with: name, source issues, one-paragraph
+         rationale, 3-5 bullet spec sketch, fit_score against rubric]
+
+        ## Emergent ideas (novel, not in any of the 26)
+        [One section per deduplicated emergent idea, with: title, one-liner,
+         which issue(s) surfaced it, why it matters for the goal, rough
+         complexity estimate (S/M/L)]
+
+        ## What was NOT proposed
+        [Short list of ideas that came up but were rejected, with 1-line reason
+         each. Keeps the signal honest.]
+
+      End with: PROPOSALS_READY
+    allowed_tools: [Read, Write, Bash, Glob]
+
+  - id: file-emergent-issue
+    depends_on: [emergent-collector]
+    bash: |
+      set -euo pipefail
+      BODY_FILE="$ARTIFACTS_DIR/emergent-proposals.md"
+      if [ ! -s "$BODY_FILE" ]; then
+        echo "No emergent proposals file; skipping." >&2
+        exit 0
+      fi
+      URL=$(gh issue create \
+        --title "Emergent proposals from cluely-brainstorm-26 ($WORKFLOW_ID)" \
+        --label "enhancement,meta,emergent" \
+        --body-file "$BODY_FILE")
+      echo "$URL" > "$ARTIFACTS_DIR/.emergent-issue-url"
+      echo "FILED: $URL"
+    timeout: 60000
+
+  # ───────────────────────────────────────────────────────
+  # Layer 5 — final report
+  # ───────────────────────────────────────────────────────
+  - id: final-report
+    depends_on: [spec-plan-generator, file-emergent-issue]
+    trigger_rule: none_failed_min_one_success
+    idle_timeout: 600000
+    prompt: |
+      You are writing the final report for Guillaume.
+
+      LOAD everything:
+        - $ARTIFACTS_DIR/goal.md
+        - $ARTIFACTS_DIR/synthesis.md
+        - $ARTIFACTS_DIR/evals/*.json
+        - $ARTIFACTS_DIR/specs/*.md
+        - $ARTIFACTS_DIR/.emergent-issue-url (may not exist if that step was skipped)
+
+      PRODUCE $ARTIFACTS_DIR/FINAL_REPORT.md — top-level deliverable:
+
+        # cluely-brainstorm-26 — Final Report
+
+        ## Workflow goal
+        [1 paragraph restatement + rubric]
+
+        ## Executive summary
+        [3-5 bullets: what should Guillaume do first, what's the biggest
+         surprise, what's the hidden blocker]
+
+        ## Ranked roadmap
+        [Table: rank | issue# or composite | title | weighted_score |
+         tranche | est. effort | spec path]
+
+        ## Tranches (execution order)
+        ### Tranche 1: Foundations (unlocks everything)
+        ### Tranche 2: Core workflow
+        ### Tranche 3: Polish
+        [Per tranche: issue list + 1-line why]
+
+        ## Composites (new features)
+        [Short table: name | source issues | priority]
+
+        ## Emergent proposals issue
+        [Link to the GitHub issue that was filed, if any]
+
+        ## Dropped
+        [Short table: issue# | title | reason]
+
+        ## What the workflow could not answer
+        [2-5 bullets: questions that need Guillaume's judgment, not more
+         AI reasoning]
+
+      Print the full final report to stdout at the end so it appears in
+      the workflow output. Then end with: REPORT_COMPLETE
+    allowed_tools: [Read, Write, Bash, Glob]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,5 @@
 - `electron/main.ts` -- AppState singleton is the service registry
 - `electron/memory/` -- SQLite graph store (memory.db) for relationship/fact tracking
 - `electron/services/` -- mid-call decision capture layer (IpcEventBus, LunrIndexer, SlidingWindowAnalyzer, TaskGeneratorBuffer, MemoryGraphWriter)
+- `electron/corpus/` -- local-corpus RAG: file + git-history indexing, embedding-based retrieval, freshness guard
+  - Config: `corpus.json` in Electron userData directory (no UI; file-based only)

--- a/electron/corpus/CorpusFreshnessGuard.ts
+++ b/electron/corpus/CorpusFreshnessGuard.ts
@@ -1,0 +1,39 @@
+// electron/corpus/CorpusFreshnessGuard.ts
+// Checks whether the corpus index is fresh enough for task dispatch
+
+import Database from 'better-sqlite3';
+
+export interface FreshnessResult {
+  stale: boolean;
+  lastIndexedAt: number | null;
+  ageHours: number | null;
+}
+
+export class CorpusFreshnessGuard {
+  private db: Database.Database;
+  private thresholdHours: number;
+
+  constructor(db: Database.Database, thresholdHours: number = 2) {
+    this.db = db;
+    this.thresholdHours = thresholdHours;
+  }
+
+  check(projectId: string): FreshnessResult {
+    const row = this.db.prepare(
+      'SELECT MAX(indexed_at) as last FROM corpus_chunks WHERE project_id = ?'
+    ).get(projectId) as { last: number | null } | undefined;
+
+    const lastIndexedAt = row?.last ?? null;
+
+    if (lastIndexedAt === null) {
+      return { stale: true, lastIndexedAt: null, ageHours: null };
+    }
+
+    const ageHours = (Date.now() - lastIndexedAt) / 3_600_000;
+    return {
+      stale: ageHours > this.thresholdHours,
+      lastIndexedAt,
+      ageHours,
+    };
+  }
+}

--- a/electron/corpus/CorpusIndexer.ts
+++ b/electron/corpus/CorpusIndexer.ts
@@ -1,0 +1,249 @@
+// electron/corpus/CorpusIndexer.ts
+// Indexes project files and git history into corpus_chunks table
+
+import Database from 'better-sqlite3';
+import { createHash } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { minimatch } from 'minimatch';
+import { CorpusProjectConfig } from './corpus.config';
+
+export interface EmbeddingProvider {
+  getEmbedding(text: string): Promise<number[]>;
+}
+
+const TARGET_CHUNK_TOKENS = 200;
+const MAX_CHUNK_TOKENS = 300;
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function chunkId(projectId: string, sourcePath: string, chunkIndex: number): string {
+  return createHash('sha256')
+    .update(`${projectId}:${sourcePath}:${chunkIndex}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+function embeddingToBlob(embedding: number[]): Buffer {
+  const buffer = Buffer.alloc(embedding.length * 4);
+  for (let i = 0; i < embedding.length; i++) {
+    buffer.writeFloatLE(embedding[i], i * 4);
+  }
+  return buffer;
+}
+
+export function chunkText(text: string, maxTokens: number = TARGET_CHUNK_TOKENS): string[] {
+  const lines = text.split('\n');
+  const chunks: string[] = [];
+  let currentChunk: string[] = [];
+  let currentTokens = 0;
+
+  for (const line of lines) {
+    const lineTokens = estimateTokens(line);
+
+    if (currentTokens + lineTokens > maxTokens && currentChunk.length > 0) {
+      chunks.push(currentChunk.join('\n'));
+      currentChunk = [];
+      currentTokens = 0;
+    }
+
+    currentChunk.push(line);
+    currentTokens += lineTokens;
+
+    // Force split if single line exceeds max
+    if (currentTokens > MAX_CHUNK_TOKENS && currentChunk.length === 1) {
+      chunks.push(currentChunk.join('\n'));
+      currentChunk = [];
+      currentTokens = 0;
+    }
+  }
+
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk.join('\n'));
+  }
+
+  return chunks;
+}
+
+function shouldIncludeFile(
+  filePath: string,
+  rootPath: string,
+  includeGlobs: string[],
+  excludeGlobs: string[]
+): boolean {
+  const relativePath = path.relative(rootPath, filePath);
+
+  const excluded = excludeGlobs.some(g => minimatch(relativePath, g));
+  if (excluded) return false;
+
+  const included = includeGlobs.some(g => minimatch(relativePath, g));
+  return included;
+}
+
+export class CorpusIndexer {
+  private db: Database.Database;
+  private embedder: EmbeddingProvider | null;
+
+  constructor(db: Database.Database, embedder: EmbeddingProvider | null = null) {
+    this.db = db;
+    this.embedder = embedder;
+  }
+
+  async indexFile(projectId: string, filePath: string, commitHash: string | null): Promise<number> {
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      console.warn(`[CorpusIndexer] Cannot read file: ${filePath}`);
+      return 0;
+    }
+
+    // Skip binary / very large files
+    if (content.length > 500_000) {
+      console.log(`[CorpusIndexer] Skipping large file: ${filePath}`);
+      return 0;
+    }
+
+    const chunks = chunkText(content);
+    const now = Date.now();
+
+    const upsert = this.db.prepare(`
+      INSERT OR REPLACE INTO corpus_chunks (id, project_id, source_path, chunk_text, embedding, commit_hash, indexed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const upsertAll = this.db.transaction(() => {
+      for (let i = 0; i < chunks.length; i++) {
+        const id = chunkId(projectId, filePath, i);
+        upsert.run(id, projectId, filePath, chunks[i], null, commitHash, now);
+      }
+    });
+    upsertAll();
+
+    // Embed asynchronously if embedder available
+    if (this.embedder) {
+      for (let i = 0; i < chunks.length; i++) {
+        try {
+          const embedding = await this.embedder.getEmbedding(chunks[i]);
+          const id = chunkId(projectId, filePath, i);
+          this.db.prepare('UPDATE corpus_chunks SET embedding = ? WHERE id = ?')
+            .run(embeddingToBlob(embedding), id);
+        } catch (err) {
+          console.warn(`[CorpusIndexer] Embedding failed for chunk ${i} of ${filePath}:`, err);
+        }
+      }
+    }
+
+    return chunks.length;
+  }
+
+  indexCommits(projectId: string, repoPath: string, cap: number): number {
+    let log: string;
+    try {
+      log = execSync(
+        `git -C "${repoPath}" log --format="%H%n%s%n%b%n---END---" -n ${cap}`,
+        { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
+      );
+    } catch {
+      console.warn(`[CorpusIndexer] Failed to read git log for ${repoPath}`);
+      return 0;
+    }
+
+    const entries = log.split('---END---\n').filter(e => e.trim());
+    const now = Date.now();
+
+    const upsert = this.db.prepare(`
+      INSERT OR REPLACE INTO corpus_chunks (id, project_id, source_path, chunk_text, embedding, commit_hash, indexed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const upsertAll = this.db.transaction(() => {
+      for (const entry of entries) {
+        const lines = entry.trim().split('\n');
+        const hash = lines[0];
+        const message = lines.slice(1).join('\n').trim();
+        if (!hash || !message) continue;
+
+        const id = chunkId(projectId, `git:${hash}`, 0);
+        upsert.run(id, projectId, `git:commit`, message, null, hash, now);
+      }
+    });
+    upsertAll();
+
+    return entries.length;
+  }
+
+  async incrementalIndex(config: CorpusProjectConfig): Promise<number> {
+    const { projectId, rootPath, includeGlobs, excludeGlobs, commitCap } = config;
+
+    // Find last indexed timestamp for this project
+    const row = this.db.prepare(
+      'SELECT MAX(indexed_at) as last FROM corpus_chunks WHERE project_id = ?'
+    ).get(projectId) as { last: number | null } | undefined;
+    const lastIndexedAt = row?.last ?? 0;
+
+    let totalChunks = 0;
+
+    // Index changed files since last index
+    const filesToIndex = this.findChangedFiles(rootPath, lastIndexedAt, includeGlobs, excludeGlobs);
+    for (const filePath of filesToIndex) {
+      totalChunks += await this.indexFile(projectId, filePath, null);
+    }
+
+    // Index recent commits
+    totalChunks += this.indexCommits(projectId, rootPath, commitCap);
+
+    console.log(`[CorpusIndexer] Indexed ${totalChunks} chunks for project ${projectId}`);
+    return totalChunks;
+  }
+
+  private findChangedFiles(
+    rootPath: string,
+    sinceMs: number,
+    includeGlobs: string[],
+    excludeGlobs: string[]
+  ): string[] {
+    const files: string[] = [];
+
+    function walk(dir: string) {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          // Skip excluded directories early
+          const relDir = path.relative(rootPath, fullPath);
+          if (excludeGlobs.some(g => minimatch(relDir + '/', g) || minimatch(relDir, g))) {
+            continue;
+          }
+          walk(fullPath);
+        } else if (entry.isFile()) {
+          if (!shouldIncludeFile(fullPath, rootPath, includeGlobs, excludeGlobs)) {
+            continue;
+          }
+
+          try {
+            const stats = fs.statSync(fullPath);
+            if (stats.mtimeMs > sinceMs) {
+              files.push(fullPath);
+            }
+          } catch {
+            // Skip inaccessible files
+          }
+        }
+      }
+    }
+
+    walk(rootPath);
+    return files;
+  }
+}

--- a/electron/corpus/CorpusIndexer.ts
+++ b/electron/corpus/CorpusIndexer.ts
@@ -116,6 +116,11 @@ export class CorpusIndexer {
     `);
 
     const upsertAll = this.db.transaction(() => {
+      // Remove old chunks for this file before re-inserting to avoid stale orphans
+      this.db.prepare(
+        'DELETE FROM corpus_chunks WHERE project_id = ? AND source_path = ?'
+      ).run(projectId, filePath);
+
       for (let i = 0; i < chunks.length; i++) {
         const id = chunkId(projectId, filePath, i);
         upsert.run(id, projectId, filePath, chunks[i], null, commitHash, now);
@@ -123,7 +128,7 @@ export class CorpusIndexer {
     });
     upsertAll();
 
-    // Embed asynchronously if embedder available
+    // Patch embeddings into stored chunks if embedder available
     if (this.embedder) {
       for (let i = 0; i < chunks.length; i++) {
         try {

--- a/electron/corpus/CorpusRetriever.ts
+++ b/electron/corpus/CorpusRetriever.ts
@@ -1,0 +1,76 @@
+// electron/corpus/CorpusRetriever.ts
+// Retrieves top-K corpus chunks via cosine similarity
+
+import Database from 'better-sqlite3';
+import { EmbeddingProvider } from './CorpusIndexer';
+
+export interface CorpusChunk {
+  id: string;
+  project_id: string;
+  source_path: string;
+  chunk_text: string;
+  commit_hash: string | null;
+  score: number;
+}
+
+function blobToEmbedding(blob: Buffer): number[] {
+  const embedding: number[] = [];
+  for (let i = 0; i < blob.length; i += 4) {
+    embedding.push(blob.readFloatLE(i));
+  }
+  return embedding;
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) return 0;
+
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  const magnitude = Math.sqrt(normA) * Math.sqrt(normB);
+  return magnitude === 0 ? 0 : dotProduct / magnitude;
+}
+
+export class CorpusRetriever {
+  private db: Database.Database;
+  private embedder: EmbeddingProvider;
+
+  constructor(db: Database.Database, embedder: EmbeddingProvider) {
+    this.db = db;
+    this.embedder = embedder;
+  }
+
+  async query(queryText: string, projectId: string, k: number = 5): Promise<CorpusChunk[]> {
+    const qEmbed = await this.embedder.getEmbedding(queryText);
+
+    const rows = this.db.prepare(
+      'SELECT * FROM corpus_chunks WHERE project_id = ? AND embedding IS NOT NULL'
+    ).all(projectId) as any[];
+
+    const scored: CorpusChunk[] = [];
+
+    for (const row of rows) {
+      const chunkEmbedding = blobToEmbedding(row.embedding);
+      const score = cosineSimilarity(qEmbed, chunkEmbedding);
+
+      scored.push({
+        id: row.id,
+        project_id: row.project_id,
+        source_path: row.source_path,
+        chunk_text: row.chunk_text,
+        commit_hash: row.commit_hash,
+        score,
+      });
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, k);
+  }
+}

--- a/electron/corpus/CorpusRetriever.ts
+++ b/electron/corpus/CorpusRetriever.ts
@@ -48,7 +48,13 @@ export class CorpusRetriever {
   }
 
   async query(queryText: string, projectId: string, k: number = 5): Promise<CorpusChunk[]> {
-    const qEmbed = await this.embedder.getEmbedding(queryText);
+    let qEmbed: number[];
+    try {
+      qEmbed = await this.embedder.getEmbedding(queryText);
+    } catch (err) {
+      console.error(`[CorpusRetriever] Failed to embed query text:`, err);
+      return [];
+    }
 
     const rows = this.db.prepare(
       'SELECT * FROM corpus_chunks WHERE project_id = ? AND embedding IS NOT NULL'
@@ -57,17 +63,21 @@ export class CorpusRetriever {
     const scored: CorpusChunk[] = [];
 
     for (const row of rows) {
-      const chunkEmbedding = blobToEmbedding(row.embedding);
-      const score = cosineSimilarity(qEmbed, chunkEmbedding);
+      try {
+        const chunkEmbedding = blobToEmbedding(row.embedding);
+        const score = cosineSimilarity(qEmbed, chunkEmbedding);
 
-      scored.push({
-        id: row.id,
-        project_id: row.project_id,
-        source_path: row.source_path,
-        chunk_text: row.chunk_text,
-        commit_hash: row.commit_hash,
-        score,
-      });
+        scored.push({
+          id: row.id,
+          project_id: row.project_id,
+          source_path: row.source_path,
+          chunk_text: row.chunk_text,
+          commit_hash: row.commit_hash,
+          score,
+        });
+      } catch (err) {
+        console.warn(`[CorpusRetriever] Skipping corrupt chunk ${row.id}:`, err);
+      }
     }
 
     scored.sort((a, b) => b.score - a.score);

--- a/electron/corpus/CorpusWatcher.ts
+++ b/electron/corpus/CorpusWatcher.ts
@@ -1,0 +1,135 @@
+// electron/corpus/CorpusWatcher.ts
+// Background daemon that watches project files and polls git HEAD
+
+import fs from 'fs';
+import { execSync } from 'child_process';
+import { CorpusProjectConfig } from './corpus.config';
+import { CorpusIndexer } from './CorpusIndexer';
+
+const DEBOUNCE_MS = 500;
+const GIT_POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class CorpusWatcher {
+  private configs: CorpusProjectConfig[];
+  private indexer: CorpusIndexer;
+  private watchers: fs.FSWatcher[] = [];
+  private gitPollTimers: ReturnType<typeof setInterval>[] = [];
+  private debounceTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private lastHeadHashes: Map<string, string> = new Map();
+
+  constructor(configs: CorpusProjectConfig[], indexer: CorpusIndexer) {
+    this.configs = configs;
+    this.indexer = indexer;
+  }
+
+  start(): void {
+    for (const config of this.configs) {
+      this.watchProject(config);
+    }
+    console.log(`[CorpusWatcher] Started watching ${this.configs.length} project(s)`);
+  }
+
+  stop(): void {
+    for (const watcher of this.watchers) {
+      watcher.close();
+    }
+    this.watchers = [];
+
+    for (const timer of this.gitPollTimers) {
+      clearInterval(timer);
+    }
+    this.gitPollTimers = [];
+
+    for (const timer of this.debounceTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.debounceTimers.clear();
+
+    console.log('[CorpusWatcher] Stopped');
+  }
+
+  private watchProject(config: CorpusProjectConfig): void {
+    const { projectId, rootPath } = config;
+
+    // File system watcher
+    try {
+      const watcher = fs.watch(rootPath, { recursive: true }, (_event, filename) => {
+        if (!filename) return;
+        this.debouncedIndex(config);
+      });
+      this.watchers.push(watcher);
+    } catch (err) {
+      console.warn(`[CorpusWatcher] Failed to watch ${rootPath}:`, err);
+    }
+
+    // Git HEAD poll
+    const initialHash = this.getGitHead(rootPath);
+    if (initialHash) {
+      this.lastHeadHashes.set(projectId, initialHash);
+    }
+
+    const timer = setInterval(() => {
+      this.pollGitHead(config);
+    }, GIT_POLL_INTERVAL_MS);
+    this.gitPollTimers.push(timer);
+
+    // Check remote if configured
+    if (config.remote) {
+      this.pollRemoteHead(config);
+    }
+  }
+
+  private debouncedIndex(config: CorpusProjectConfig): void {
+    const existing = this.debounceTimers.get(config.projectId);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.debounceTimers.delete(config.projectId);
+      this.indexer.incrementalIndex(config).catch(err => {
+        console.error(`[CorpusWatcher] Incremental index failed for ${config.projectId}:`, err);
+      });
+    }, DEBOUNCE_MS);
+
+    this.debounceTimers.set(config.projectId, timer);
+  }
+
+  private getGitHead(repoPath: string): string | null {
+    try {
+      return execSync(`git -C "${repoPath}" rev-parse HEAD`, { encoding: 'utf-8' }).trim();
+    } catch {
+      return null;
+    }
+  }
+
+  private pollGitHead(config: CorpusProjectConfig): void {
+    const { projectId, rootPath } = config;
+    const currentHead = this.getGitHead(rootPath);
+    if (!currentHead) return;
+
+    const lastHead = this.lastHeadHashes.get(projectId);
+    if (lastHead && lastHead !== currentHead) {
+      console.log(`[CorpusWatcher] HEAD changed for ${projectId}: ${lastHead.slice(0, 8)} → ${currentHead.slice(0, 8)}`);
+      this.lastHeadHashes.set(projectId, currentHead);
+      this.indexer.incrementalIndex(config).catch(err => {
+        console.error(`[CorpusWatcher] Git poll index failed for ${projectId}:`, err);
+      });
+    } else if (!lastHead) {
+      this.lastHeadHashes.set(projectId, currentHead);
+    }
+  }
+
+  private pollRemoteHead(config: CorpusProjectConfig): void {
+    if (!config.remote) return;
+
+    const { sshHost, remotePath } = config.remote;
+    try {
+      const remoteHead = execSync(
+        `ssh "${sshHost}" "git -C '${remotePath}' rev-parse HEAD"`,
+        { encoding: 'utf-8', timeout: 10_000 }
+      ).trim();
+      console.log(`[CorpusWatcher] Remote HEAD for ${config.projectId}: ${remoteHead.slice(0, 8)}`);
+    } catch (err) {
+      console.warn(`[CorpusWatcher] Remote check failed for ${config.projectId} (degrading gracefully):`, err);
+    }
+  }
+}

--- a/electron/corpus/TaskGeneratorContext.ts
+++ b/electron/corpus/TaskGeneratorContext.ts
@@ -1,0 +1,83 @@
+// electron/corpus/TaskGeneratorContext.ts
+// Injects corpus citations into task generation prompts
+
+import { CorpusRetriever, CorpusChunk } from './CorpusRetriever';
+import { CorpusFreshnessGuard } from './CorpusFreshnessGuard';
+
+export interface TaskCitation {
+  source_path: string;
+  chunk_text: string;
+  commit_hash: string | null;
+  score: number;
+}
+
+export interface GeneratedTask {
+  title: string;
+  description: string;
+  citations: TaskCitation[];
+}
+
+export interface TaskGeneratorContextOptions {
+  retriever: CorpusRetriever;
+  freshnessGuard?: CorpusFreshnessGuard;
+  projectId: string;
+  topK?: number;
+}
+
+export class TaskGeneratorContext {
+  private retriever: CorpusRetriever;
+  private freshnessGuard: CorpusFreshnessGuard | null;
+  private projectId: string;
+  private topK: number;
+
+  constructor(options: TaskGeneratorContextOptions) {
+    this.retriever = options.retriever;
+    this.freshnessGuard = options.freshnessGuard ?? null;
+    this.projectId = options.projectId;
+    this.topK = options.topK ?? 5;
+  }
+
+  async buildSystemPrompt(transcriptText: string): Promise<{ prompt: string; citations: TaskCitation[] }> {
+    // Check freshness if guard is available
+    if (this.freshnessGuard) {
+      const freshness = this.freshnessGuard.check(this.projectId);
+      if (freshness.stale) {
+        console.warn(`[TaskGeneratorContext] Corpus index is stale for ${this.projectId} (${freshness.ageHours?.toFixed(1)}h old)`);
+      }
+    }
+
+    // Query corpus with first 500 chars of transcript as search text
+    const queryText = transcriptText.slice(0, 500);
+    const chunks = await this.retriever.query(queryText, this.projectId, this.topK);
+
+    const citations = chunks.map(chunkToCitation);
+
+    // Build KB context section
+    const kbSection = formatKBSection(chunks);
+
+    const prompt = kbSection;
+    return { prompt, citations };
+  }
+}
+
+function chunkToCitation(chunk: CorpusChunk): TaskCitation {
+  return {
+    source_path: chunk.source_path,
+    chunk_text: chunk.chunk_text,
+    commit_hash: chunk.commit_hash,
+    score: chunk.score,
+  };
+}
+
+function formatKBSection(chunks: CorpusChunk[]): string {
+  if (chunks.length === 0) return '';
+
+  const entries = chunks.map((c, i) => {
+    const source = c.commit_hash
+      ? `${c.source_path} (commit: ${c.commit_hash.slice(0, 8)})`
+      : c.source_path;
+    return `### Source ${i + 1}: ${source}\n\`\`\`\n${c.chunk_text}\n\`\`\``;
+  });
+
+  return `## Local KB Context\n\nThe following code/documentation snippets are relevant to this conversation:\n\n${entries.join('\n\n')}`;
+}

--- a/electron/corpus/UploadGuard.ts
+++ b/electron/corpus/UploadGuard.ts
@@ -1,0 +1,37 @@
+// electron/corpus/UploadGuard.ts
+// Prevents corpus data from leaking to external uploads (e.g. NotebookLM)
+
+import path from 'path';
+
+export class CorpusLeakError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CorpusLeakError';
+  }
+}
+
+export class UploadGuard {
+  private denyList: string[];
+
+  constructor(corpusRootPaths: string[]) {
+    this.denyList = corpusRootPaths.map(p => path.resolve(p));
+  }
+
+  checkPath(sourcePath: string): void {
+    const resolved = path.resolve(sourcePath);
+
+    for (const denied of this.denyList) {
+      if (resolved.startsWith(denied)) {
+        throw new CorpusLeakError(
+          `Corpus path blocked from upload: ${sourcePath} is under corpus root ${denied}`
+        );
+      }
+    }
+  }
+
+  checkPayload(payload: { sourcePath?: string; content?: string }): void {
+    if (payload.sourcePath) {
+      this.checkPath(payload.sourcePath);
+    }
+  }
+}

--- a/electron/corpus/UploadGuard.ts
+++ b/electron/corpus/UploadGuard.ts
@@ -21,7 +21,7 @@ export class UploadGuard {
     const resolved = path.resolve(sourcePath);
 
     for (const denied of this.denyList) {
-      if (resolved.startsWith(denied)) {
+      if (resolved === denied || resolved.startsWith(denied + path.sep)) {
         throw new CorpusLeakError(
           `Corpus path blocked from upload: ${sourcePath} is under corpus root ${denied}`
         );

--- a/electron/corpus/corpus.config.ts
+++ b/electron/corpus/corpus.config.ts
@@ -1,0 +1,77 @@
+// electron/corpus/corpus.config.ts
+// Configuration schema and loader for local corpus RAG
+
+import fs from 'fs';
+import path from 'path';
+import { app } from 'electron';
+
+export interface CorpusProjectConfig {
+  projectId: string;
+  rootPath: string;
+  includeGlobs: string[];
+  excludeGlobs: string[];
+  commitCap: number;
+  freshnessThresholdHours: number;
+  remote?: { sshHost: string; remotePath: string };
+}
+
+export interface CorpusConfig {
+  projects: CorpusProjectConfig[];
+}
+
+const DEFAULT_INCLUDE_GLOBS = ['**/*.ts', '**/*.md', '**/*.py', '**/*.js', '**/*.tsx', '**/*.jsx'];
+const DEFAULT_EXCLUDE_GLOBS = ['node_modules/**', 'dist/**', 'dist-electron/**', '.git/**', 'build/**'];
+const DEFAULT_COMMIT_CAP = 100;
+const DEFAULT_FRESHNESS_THRESHOLD_HOURS = 2;
+
+function getConfigPath(): string {
+  const userDataPath = app.getPath('userData');
+  return path.join(userDataPath, 'corpus.json');
+}
+
+export function loadCorpusConfig(): CorpusConfig {
+  const configPath = getConfigPath();
+
+  try {
+    if (fs.existsSync(configPath)) {
+      const raw = fs.readFileSync(configPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      return normalizeConfig(parsed);
+    }
+  } catch (error) {
+    console.warn('[CorpusConfig] Failed to read corpus.json, using defaults:', error);
+  }
+
+  return { projects: [] };
+}
+
+function normalizeConfig(raw: any): CorpusConfig {
+  if (!raw || !Array.isArray(raw.projects)) {
+    return { projects: [] };
+  }
+
+  return {
+    projects: raw.projects.map((p: any) => ({
+      projectId: String(p.projectId || ''),
+      rootPath: String(p.rootPath || ''),
+      includeGlobs: Array.isArray(p.includeGlobs) ? p.includeGlobs : DEFAULT_INCLUDE_GLOBS,
+      excludeGlobs: Array.isArray(p.excludeGlobs) ? p.excludeGlobs : DEFAULT_EXCLUDE_GLOBS,
+      commitCap: typeof p.commitCap === 'number' ? p.commitCap : DEFAULT_COMMIT_CAP,
+      freshnessThresholdHours: typeof p.freshnessThresholdHours === 'number'
+        ? p.freshnessThresholdHours
+        : DEFAULT_FRESHNESS_THRESHOLD_HOURS,
+      ...(p.remote ? { remote: { sshHost: String(p.remote.sshHost), remotePath: String(p.remote.remotePath) } } : {}),
+    })),
+  };
+}
+
+export function getDefaultProjectConfig(projectId: string, rootPath: string): CorpusProjectConfig {
+  return {
+    projectId,
+    rootPath,
+    includeGlobs: DEFAULT_INCLUDE_GLOBS,
+    excludeGlobs: DEFAULT_EXCLUDE_GLOBS,
+    commitCap: DEFAULT_COMMIT_CAP,
+    freshnessThresholdHours: DEFAULT_FRESHNESS_THRESHOLD_HOURS,
+  };
+}

--- a/electron/corpus/index.ts
+++ b/electron/corpus/index.ts
@@ -1,0 +1,13 @@
+// electron/corpus/index.ts
+export { loadCorpusConfig, getDefaultProjectConfig } from './corpus.config';
+export type { CorpusProjectConfig, CorpusConfig } from './corpus.config';
+export { CorpusIndexer, chunkText } from './CorpusIndexer';
+export type { EmbeddingProvider } from './CorpusIndexer';
+export { CorpusRetriever } from './CorpusRetriever';
+export type { CorpusChunk } from './CorpusRetriever';
+export { CorpusFreshnessGuard } from './CorpusFreshnessGuard';
+export type { FreshnessResult } from './CorpusFreshnessGuard';
+export { CorpusWatcher } from './CorpusWatcher';
+export { TaskGeneratorContext } from './TaskGeneratorContext';
+export type { TaskCitation, GeneratedTask, TaskGeneratorContextOptions } from './TaskGeneratorContext';
+export { UploadGuard, CorpusLeakError } from './UploadGuard';

--- a/electron/db/DatabaseManager.ts
+++ b/electron/db/DatabaseManager.ts
@@ -186,6 +186,24 @@ export class DatabaseManager {
             this.db.exec("CREATE INDEX IF NOT EXISTS idx_chunks_meeting ON chunks(meeting_id)");
         } catch (e) { /* Index may exist */ }
 
+        // Corpus RAG: Local project corpus chunks (git + docs + code)
+        const createCorpusChunksTable = `
+            CREATE TABLE IF NOT EXISTS corpus_chunks (
+                id TEXT PRIMARY KEY,
+                project_id TEXT NOT NULL,
+                source_path TEXT NOT NULL,
+                chunk_text TEXT NOT NULL,
+                embedding BLOB,
+                commit_hash TEXT,
+                indexed_at INTEGER NOT NULL
+            );
+        `;
+        this.db.exec(createCorpusChunksTable);
+
+        try {
+            this.db.exec("CREATE INDEX IF NOT EXISTS idx_corpus_chunks_project ON corpus_chunks(project_id)");
+        } catch (e) { /* Index may exist */ }
+
         // Migration for existing tables
         try {
             this.db.exec("ALTER TABLE meetings ADD COLUMN calendar_event_id TEXT");
@@ -511,6 +529,7 @@ export class DatabaseManager {
 
         try {
             // Clear all tables (order matters due to foreign keys, but SQLite handles with ON DELETE CASCADE)
+            this.db.exec('DELETE FROM corpus_chunks');
             this.db.exec('DELETE FROM embedding_queue');
             this.db.exec('DELETE FROM chunk_summaries');
             this.db.exec('DELETE FROM chunks');

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -90,6 +90,9 @@ import { LunrIndexer } from "./services/LunrIndexer"
 import { SlidingWindowAnalyzer } from "./services/SlidingWindowAnalyzer"
 import { taskGeneratorBuffer } from "./services/TaskGeneratorBuffer"
 import { MemoryGraphWriter } from "./services/MemoryGraphWriter"
+import { CorpusWatcher } from "./corpus/CorpusWatcher"
+import { CorpusIndexer } from "./corpus/CorpusIndexer"
+import { loadCorpusConfig } from "./corpus/corpus.config"
 
 export class AppState {
   private static instance: AppState | null = null
@@ -104,6 +107,7 @@ export class AppState {
   private themeManager: ThemeManager
   private ragManager: RAGManager | null = null
   private memoryManager: MemoryManager
+  private corpusWatcher: CorpusWatcher | null = null
   private tray: Tray | null = null
   private updateAvailable: boolean = false
   private disguiseMode: 'terminal' | 'settings' | 'activity' | 'none' = 'terminal'
@@ -189,6 +193,9 @@ export class AppState {
     // Initialize MemoryManager (separate memory.db for graph + facts)
     this.memoryManager = MemoryManager.getInstance()
 
+    // Initialize Corpus Watcher (local corpus RAG indexing)
+    this.initializeCorpusWatcher()
+
     this.setupIntelligenceEvents()
 
     // Setup Ollama IPC
@@ -224,6 +231,28 @@ export class AppState {
       }
     } catch (error) {
       console.error('[AppState] Failed to initialize RAGManager:', error);
+    }
+  }
+
+  private initializeCorpusWatcher(): void {
+    try {
+      const corpusConfig = loadCorpusConfig();
+      if (corpusConfig.projects.length === 0) {
+        console.log('[AppState] No corpus projects configured, skipping watcher');
+        return;
+      }
+
+      const db = DatabaseManager.getInstance();
+      // @ts-ignore - accessing private db for CorpusIndexer
+      const sqliteDb = db['db'];
+      if (!sqliteDb) return;
+
+      const indexer = new CorpusIndexer(sqliteDb);
+      this.corpusWatcher = new CorpusWatcher(corpusConfig.projects, indexer);
+      this.corpusWatcher.start();
+      console.log('[AppState] CorpusWatcher initialized');
+    } catch (error) {
+      console.error('[AppState] Failed to initialize CorpusWatcher:', error);
     }
   }
 

--- a/test/corpus/CorpusFreshnessGuard.test.ts
+++ b/test/corpus/CorpusFreshnessGuard.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { CorpusFreshnessGuard } from '../../electron/corpus/CorpusFreshnessGuard';
+
+describe('CorpusFreshnessGuard', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS corpus_chunks (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        chunk_text TEXT NOT NULL,
+        embedding BLOB,
+        commit_hash TEXT,
+        indexed_at INTEGER NOT NULL
+      );
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns stale=true when no chunks exist', () => {
+    const guard = new CorpusFreshnessGuard(db, 2);
+    const result = guard.check('proj-1');
+    expect(result.stale).toBe(true);
+    expect(result.lastIndexedAt).toBeNull();
+    expect(result.ageHours).toBeNull();
+  });
+
+  it('returns stale=true when index is older than threshold', () => {
+    const threeHoursAgo = Date.now() - 3 * 3_600_000;
+    db.prepare(`
+      INSERT INTO corpus_chunks (id, project_id, source_path, chunk_text, indexed_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run('c1', 'proj-1', 'src/a.ts', 'code', threeHoursAgo);
+
+    const guard = new CorpusFreshnessGuard(db, 2);
+    const result = guard.check('proj-1');
+    expect(result.stale).toBe(true);
+    expect(result.ageHours).toBeGreaterThan(2);
+  });
+
+  it('returns stale=false when index is recent', () => {
+    const oneHourAgo = Date.now() - 1 * 3_600_000;
+    db.prepare(`
+      INSERT INTO corpus_chunks (id, project_id, source_path, chunk_text, indexed_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run('c1', 'proj-1', 'src/a.ts', 'code', oneHourAgo);
+
+    const guard = new CorpusFreshnessGuard(db, 2);
+    const result = guard.check('proj-1');
+    expect(result.stale).toBe(false);
+    expect(result.ageHours).toBeLessThan(2);
+  });
+
+  it('checks freshness per project', () => {
+    const recent = Date.now() - 0.5 * 3_600_000;
+    const old = Date.now() - 5 * 3_600_000;
+
+    db.prepare(`INSERT INTO corpus_chunks (id, project_id, source_path, chunk_text, indexed_at) VALUES (?, ?, ?, ?, ?)`).run('c1', 'fresh-proj', 'a.ts', 'code', recent);
+    db.prepare(`INSERT INTO corpus_chunks (id, project_id, source_path, chunk_text, indexed_at) VALUES (?, ?, ?, ?, ?)`).run('c2', 'stale-proj', 'b.ts', 'code', old);
+
+    const guard = new CorpusFreshnessGuard(db, 2);
+    expect(guard.check('fresh-proj').stale).toBe(false);
+    expect(guard.check('stale-proj').stale).toBe(true);
+  });
+});

--- a/test/corpus/CorpusIndexer.test.ts
+++ b/test/corpus/CorpusIndexer.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { CorpusIndexer, chunkText } from '../../electron/corpus/CorpusIndexer';
+
+describe('chunkText', () => {
+  it('splits text into chunks respecting token limit', () => {
+    const text = Array(100).fill('hello world this is a test line').join('\n');
+    const chunks = chunkText(text, 200);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThan(200 * 4 + 200); // rough upper bound
+    }
+  });
+
+  it('returns single chunk for short text', () => {
+    const chunks = chunkText('hello world');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe('hello world');
+  });
+
+  it('handles empty text', () => {
+    const chunks = chunkText('');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe('');
+  });
+});
+
+describe('CorpusIndexer', () => {
+  let db: Database.Database;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS corpus_chunks (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        chunk_text TEXT NOT NULL,
+        embedding BLOB,
+        commit_hash TEXT,
+        indexed_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_corpus_chunks_project ON corpus_chunks(project_id);
+    `);
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'corpus-test-'));
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('indexes a file and stores chunks in DB', async () => {
+    const filePath = path.join(tmpDir, 'foo.ts');
+    fs.writeFileSync(filePath, 'const x = 1;\nconst y = 2;\nexport { x, y };');
+
+    const indexer = new CorpusIndexer(db);
+    const count = await indexer.indexFile('proj-1', filePath, null);
+
+    expect(count).toBeGreaterThan(0);
+
+    const rows = db.prepare('SELECT * FROM corpus_chunks WHERE project_id = ?').all('proj-1') as any[];
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].source_path).toBe(filePath);
+    expect(rows[0].chunk_text).toContain('const x = 1');
+  });
+
+  it('indexes a file with embeddings when embedder provided', async () => {
+    const filePath = path.join(tmpDir, 'bar.ts');
+    fs.writeFileSync(filePath, 'function bar() { return 42; }');
+
+    const mockEmbedder = {
+      getEmbedding: async (_text: string) => [0.1, 0.2, 0.3],
+    };
+
+    const indexer = new CorpusIndexer(db, mockEmbedder);
+    await indexer.indexFile('proj-1', filePath, 'abc123');
+
+    const rows = db.prepare('SELECT * FROM corpus_chunks WHERE project_id = ?').all('proj-1') as any[];
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].embedding).not.toBeNull();
+    expect(rows[0].commit_hash).toBe('abc123');
+  });
+
+  it('skips files larger than 500KB', async () => {
+    const filePath = path.join(tmpDir, 'huge.ts');
+    fs.writeFileSync(filePath, 'x'.repeat(600_000));
+
+    const indexer = new CorpusIndexer(db);
+    const count = await indexer.indexFile('proj-1', filePath, null);
+    expect(count).toBe(0);
+  });
+
+  it('handles non-existent file gracefully', async () => {
+    const indexer = new CorpusIndexer(db);
+    const count = await indexer.indexFile('proj-1', '/nonexistent/file.ts', null);
+    expect(count).toBe(0);
+  });
+});

--- a/test/corpus/CorpusIndexer.test.ts
+++ b/test/corpus/CorpusIndexer.test.ts
@@ -1,9 +1,15 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { execSync } from 'child_process';
 import { CorpusIndexer, chunkText } from '../../electron/corpus/CorpusIndexer';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, execSync: vi.fn(actual.execSync) };
+});
 
 describe('chunkText', () => {
   it('splits text into chunks respecting token limit', () => {
@@ -100,5 +106,117 @@ describe('CorpusIndexer', () => {
     const indexer = new CorpusIndexer(db);
     const count = await indexer.indexFile('proj-1', '/nonexistent/file.ts', null);
     expect(count).toBe(0);
+  });
+
+  it('removes stale chunks when re-indexing a shrunk file', async () => {
+    const filePath = path.join(tmpDir, 'shrink.ts');
+
+    // First index: large file producing multiple chunks
+    const longContent = Array(80).fill('const line = "some code content here";').join('\n');
+    fs.writeFileSync(filePath, longContent);
+
+    const indexer = new CorpusIndexer(db);
+    const count1 = await indexer.indexFile('proj-1', filePath, null);
+    expect(count1).toBeGreaterThan(1);
+
+    const rows1 = db.prepare('SELECT * FROM corpus_chunks WHERE project_id = ? AND source_path = ?')
+      .all('proj-1', filePath) as any[];
+    expect(rows1.length).toBe(count1);
+
+    // Second index: file shrinks to 1 chunk
+    fs.writeFileSync(filePath, 'const x = 1;');
+    const count2 = await indexer.indexFile('proj-1', filePath, null);
+    expect(count2).toBe(1);
+
+    // Verify old chunks are gone
+    const rows2 = db.prepare('SELECT * FROM corpus_chunks WHERE project_id = ? AND source_path = ?')
+      .all('proj-1', filePath) as any[];
+    expect(rows2.length).toBe(1);
+  });
+
+  describe('indexCommits', () => {
+    const mockedExecSync = vi.mocked(execSync);
+
+    afterEach(() => {
+      mockedExecSync.mockReset();
+    });
+
+    it('parses git log output and stores commit chunks', () => {
+      const gitLog = [
+        'abc123\nFix: handle edge case\nDetailed body here\n---END---',
+        'def456\nFeat: add feature\nMore details\n---END---',
+        '',
+      ].join('\n');
+
+      mockedExecSync.mockReturnValueOnce(gitLog);
+
+      const indexer = new CorpusIndexer(db);
+      const count = indexer.indexCommits('proj-1', '/fake/repo', 10);
+
+      expect(count).toBe(2);
+
+      const rows = db.prepare('SELECT * FROM corpus_chunks WHERE project_id = ?').all('proj-1') as any[];
+      expect(rows.length).toBe(2);
+      expect(rows.some((r: any) => r.commit_hash === 'abc123')).toBe(true);
+      expect(rows.some((r: any) => r.commit_hash === 'def456')).toBe(true);
+    });
+
+    it('handles git log failure gracefully', () => {
+      mockedExecSync.mockImplementationOnce(() => { throw new Error('not a git repo'); });
+
+      const indexer = new CorpusIndexer(db);
+      const count = indexer.indexCommits('proj-1', '/fake/repo', 10);
+      expect(count).toBe(0);
+    });
+
+    it('skips entries with empty messages', () => {
+      const gitLog = 'abc123\n\n---END---\ndef456\nReal message\n---END---\n';
+      mockedExecSync.mockReturnValueOnce(gitLog);
+
+      const indexer = new CorpusIndexer(db);
+      const count = indexer.indexCommits('proj-1', '/fake/repo', 10);
+
+      const rows = db.prepare('SELECT * FROM corpus_chunks WHERE project_id = ?').all('proj-1') as any[];
+      expect(rows.length).toBe(1);
+      expect(rows[0].commit_hash).toBe('def456');
+    });
+  });
+
+  describe('incrementalIndex', () => {
+    const mockedExecSync = vi.mocked(execSync);
+
+    afterEach(() => {
+      mockedExecSync.mockReset();
+    });
+
+    it('indexes files and commits from a project config', async () => {
+      const srcDir = path.join(tmpDir, 'src');
+      fs.mkdirSync(srcDir, { recursive: true });
+      fs.writeFileSync(path.join(srcDir, 'main.ts'), 'export const main = true;');
+      fs.writeFileSync(path.join(srcDir, 'util.ts'), 'export function util() {}');
+
+      const gitLog = 'abc123\nCommit message\n---END---\n';
+      mockedExecSync.mockReturnValue(gitLog);
+
+      const indexer = new CorpusIndexer(db);
+      const config = {
+        projectId: 'test-proj',
+        rootPath: tmpDir,
+        includeGlobs: ['**/*.ts'],
+        excludeGlobs: ['node_modules/**'],
+        commitCap: 10,
+        freshnessThresholdHours: 2,
+      };
+
+      const totalChunks = await indexer.incrementalIndex(config);
+      expect(totalChunks).toBeGreaterThan(0);
+
+      const rows = db.prepare('SELECT * FROM corpus_chunks WHERE project_id = ?').all('test-proj') as any[];
+      expect(rows.length).toBeGreaterThan(0);
+
+      const filePaths = [...new Set(rows.map((r: any) => r.source_path))];
+      expect(filePaths.some((p: string) => p.includes('main.ts'))).toBe(true);
+      expect(filePaths.some((p: string) => p === 'git:commit')).toBe(true);
+    });
   });
 });

--- a/test/corpus/CorpusRetriever.test.ts
+++ b/test/corpus/CorpusRetriever.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { CorpusRetriever } from '../../electron/corpus/CorpusRetriever';
+
+function embeddingToBlob(embedding: number[]): Buffer {
+  const buffer = Buffer.alloc(embedding.length * 4);
+  for (let i = 0; i < embedding.length; i++) {
+    buffer.writeFloatLE(embedding[i], i * 4);
+  }
+  return buffer;
+}
+
+describe('CorpusRetriever', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS corpus_chunks (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        chunk_text TEXT NOT NULL,
+        embedding BLOB,
+        commit_hash TEXT,
+        indexed_at INTEGER NOT NULL
+      );
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns top-K chunks sorted by cosine similarity', async () => {
+    // Seed 3 chunks with known embeddings
+    const insert = db.prepare(`
+      INSERT INTO corpus_chunks (id, project_id, source_path, chunk_text, embedding, commit_hash, indexed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    insert.run('c1', 'proj-1', 'src/auth.ts', 'token handling code', embeddingToBlob([1, 0, 0]), null, Date.now());
+    insert.run('c2', 'proj-1', 'src/db.ts', 'database queries', embeddingToBlob([0, 1, 0]), null, Date.now());
+    insert.run('c3', 'proj-1', 'src/api.ts', 'api endpoints', embeddingToBlob([0.7, 0.7, 0]), null, Date.now());
+
+    const mockEmbedder = {
+      getEmbedding: async (_text: string) => [1, 0, 0], // most similar to c1
+    };
+
+    const retriever = new CorpusRetriever(db, mockEmbedder);
+    const results = await retriever.query('authentication', 'proj-1', 2);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].source_path).toBe('src/auth.ts');
+    expect(results[0].score).toBeCloseTo(1.0);
+    expect(results[0]).toMatchObject({
+      source_path: expect.any(String),
+      chunk_text: expect.any(String),
+      score: expect.any(Number),
+    });
+  });
+
+  it('returns empty for project with no chunks', async () => {
+    const mockEmbedder = {
+      getEmbedding: async (_text: string) => [1, 0, 0],
+    };
+
+    const retriever = new CorpusRetriever(db, mockEmbedder);
+    const results = await retriever.query('anything', 'empty-proj', 5);
+    expect(results).toHaveLength(0);
+  });
+
+  it('skips chunks without embeddings', async () => {
+    const insert = db.prepare(`
+      INSERT INTO corpus_chunks (id, project_id, source_path, chunk_text, embedding, commit_hash, indexed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    insert.run('c1', 'proj-1', 'src/a.ts', 'code a', null, null, Date.now()); // no embedding
+    insert.run('c2', 'proj-1', 'src/b.ts', 'code b', embeddingToBlob([1, 0, 0]), null, Date.now());
+
+    const mockEmbedder = { getEmbedding: async () => [1, 0, 0] };
+    const retriever = new CorpusRetriever(db, mockEmbedder);
+    const results = await retriever.query('query', 'proj-1', 5);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].source_path).toBe('src/b.ts');
+  });
+});

--- a/test/corpus/CorpusRetriever.test.ts
+++ b/test/corpus/CorpusRetriever.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import { CorpusRetriever } from '../../electron/corpus/CorpusRetriever';
 
@@ -85,5 +85,40 @@ describe('CorpusRetriever', () => {
 
     expect(results).toHaveLength(1);
     expect(results[0].source_path).toBe('src/b.ts');
+  });
+
+  it('returns empty array when embedder throws on query', async () => {
+    const failingEmbedder = {
+      getEmbedding: async () => { throw new Error('embedding service down'); },
+    };
+
+    const retriever = new CorpusRetriever(db, failingEmbedder);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const results = await retriever.query('anything', 'proj-1', 5);
+
+    expect(results).toHaveLength(0);
+    consoleSpy.mockRestore();
+  });
+
+  it('skips corrupt chunks without crashing', async () => {
+    const insert = db.prepare(`
+      INSERT INTO corpus_chunks (id, project_id, source_path, chunk_text, embedding, commit_hash, indexed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    // Insert a chunk with a corrupt (too-short) embedding blob
+    insert.run('corrupt', 'proj-1', 'src/bad.ts', 'bad code', Buffer.from([0x00, 0x01]), null, Date.now());
+    insert.run('good', 'proj-1', 'src/good.ts', 'good code', embeddingToBlob([1, 0, 0]), null, Date.now());
+
+    const mockEmbedder = { getEmbedding: async () => [1, 0, 0] };
+    const retriever = new CorpusRetriever(db, mockEmbedder);
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const results = await retriever.query('query', 'proj-1', 5);
+
+    // Should still return the good chunk
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some(r => r.source_path === 'src/good.ts')).toBe(true);
+    consoleSpy.mockRestore();
   });
 });

--- a/test/corpus/CorpusWatcher.test.ts
+++ b/test/corpus/CorpusWatcher.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { CorpusWatcher } from '../../electron/corpus/CorpusWatcher';
+import { CorpusProjectConfig } from '../../electron/corpus/corpus.config';
+
+describe('CorpusWatcher', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'corpus-watcher-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('triggers incrementalIndex when a watched file changes', async () => {
+    const config: CorpusProjectConfig = {
+      projectId: 'p1',
+      rootPath: tmpDir,
+      includeGlobs: ['**/*.ts'],
+      excludeGlobs: ['node_modules/**'],
+      commitCap: 100,
+      freshnessThresholdHours: 2,
+    };
+
+    const mockIndexer = {
+      incrementalIndex: vi.fn().mockResolvedValue(5),
+      indexFile: vi.fn(),
+      indexCommits: vi.fn(),
+    };
+
+    const watcher = new CorpusWatcher([config], mockIndexer as any);
+    watcher.start();
+
+    // Write a file to trigger the watcher
+    fs.writeFileSync(path.join(tmpDir, 'new.ts'), 'const x = 1;');
+
+    // Wait for debounce (500ms) + buffer
+    await new Promise(r => setTimeout(r, 1200));
+
+    watcher.stop();
+
+    expect(mockIndexer.incrementalIndex).toHaveBeenCalledWith(config);
+  });
+
+  it('stops cleanly without errors', () => {
+    const config: CorpusProjectConfig = {
+      projectId: 'p1',
+      rootPath: tmpDir,
+      includeGlobs: ['**/*.ts'],
+      excludeGlobs: [],
+      commitCap: 100,
+      freshnessThresholdHours: 2,
+    };
+
+    const mockIndexer = { incrementalIndex: vi.fn() };
+    const watcher = new CorpusWatcher([config], mockIndexer as any);
+    watcher.start();
+    watcher.stop();
+    // No error = success
+  });
+});

--- a/test/corpus/TaskGeneratorContext.test.ts
+++ b/test/corpus/TaskGeneratorContext.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TaskGeneratorContext } from '../../electron/corpus/TaskGeneratorContext';
+
+describe('TaskGeneratorContext', () => {
+  it('injects corpus chunks into system prompt', async () => {
+    const mockRetriever = {
+      query: vi.fn().mockResolvedValue([
+        { id: 'c1', project_id: 'proj-1', source_path: 'src/auth.ts', chunk_text: 'token handling', commit_hash: null, score: 0.9 },
+        { id: 'c2', project_id: 'proj-1', source_path: 'src/db.ts', chunk_text: 'database code', commit_hash: 'abc123', score: 0.7 },
+      ]),
+    };
+
+    const ctx = new TaskGeneratorContext({
+      retriever: mockRetriever as any,
+      projectId: 'proj-1',
+    });
+
+    const { prompt, citations } = await ctx.buildSystemPrompt('auth token meeting transcript');
+
+    expect(prompt).toContain('src/auth.ts');
+    expect(prompt).toContain('token handling');
+    expect(prompt).toContain('Local KB Context');
+    expect(citations).toHaveLength(2);
+    expect(citations[0].source_path).toBe('src/auth.ts');
+    expect(citations[0].score).toBe(0.9);
+  });
+
+  it('returns empty prompt when no chunks found', async () => {
+    const mockRetriever = {
+      query: vi.fn().mockResolvedValue([]),
+    };
+
+    const ctx = new TaskGeneratorContext({
+      retriever: mockRetriever as any,
+      projectId: 'proj-1',
+    });
+
+    const { prompt, citations } = await ctx.buildSystemPrompt('some meeting text');
+    expect(prompt).toBe('');
+    expect(citations).toHaveLength(0);
+  });
+
+  it('includes commit hash in citation when present', async () => {
+    const mockRetriever = {
+      query: vi.fn().mockResolvedValue([
+        { id: 'c1', project_id: 'proj-1', source_path: 'git:commit', chunk_text: 'feat: add auth', commit_hash: 'deadbeef', score: 0.8 },
+      ]),
+    };
+
+    const ctx = new TaskGeneratorContext({
+      retriever: mockRetriever as any,
+      projectId: 'proj-1',
+    });
+
+    const { prompt, citations } = await ctx.buildSystemPrompt('commit review');
+    expect(prompt).toContain('deadbeef');
+    expect(citations[0].commit_hash).toBe('deadbeef');
+  });
+
+  it('warns when corpus is stale but still returns results', async () => {
+    const mockRetriever = {
+      query: vi.fn().mockResolvedValue([
+        { id: 'c1', project_id: 'proj-1', source_path: 'src/a.ts', chunk_text: 'code', commit_hash: null, score: 0.5 },
+      ]),
+    };
+
+    const mockGuard = {
+      check: vi.fn().mockReturnValue({ stale: true, lastIndexedAt: Date.now() - 5 * 3_600_000, ageHours: 5 }),
+    };
+
+    const ctx = new TaskGeneratorContext({
+      retriever: mockRetriever as any,
+      freshnessGuard: mockGuard as any,
+      projectId: 'proj-1',
+    });
+
+    const { citations } = await ctx.buildSystemPrompt('meeting text');
+    expect(citations).toHaveLength(1);
+    expect(mockGuard.check).toHaveBeenCalledWith('proj-1');
+  });
+});

--- a/test/corpus/UploadGuard.test.ts
+++ b/test/corpus/UploadGuard.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { UploadGuard, CorpusLeakError } from '../../electron/corpus/UploadGuard';
+
+describe('UploadGuard', () => {
+  it('throws CorpusLeakError when source path is under corpus root', () => {
+    const guard = new UploadGuard(['/Users/g/projects']);
+
+    expect(() => {
+      guard.checkPath('/Users/g/projects/app/foo.ts');
+    }).toThrow(CorpusLeakError);
+  });
+
+  it('allows paths outside corpus roots', () => {
+    const guard = new UploadGuard(['/Users/g/projects']);
+
+    expect(() => {
+      guard.checkPath('/Users/g/documents/notes.md');
+    }).not.toThrow();
+  });
+
+  it('checks payload sourcePath field', () => {
+    const guard = new UploadGuard(['/Users/g/projects']);
+
+    expect(() => {
+      guard.checkPayload({ sourcePath: '/Users/g/projects/app/secret.ts', content: 'data' });
+    }).toThrow(CorpusLeakError);
+  });
+
+  it('allows payload without sourcePath', () => {
+    const guard = new UploadGuard(['/Users/g/projects']);
+
+    expect(() => {
+      guard.checkPayload({ content: 'just text' });
+    }).not.toThrow();
+  });
+
+  it('handles multiple corpus roots', () => {
+    const guard = new UploadGuard(['/Users/g/work', '/Users/g/oss']);
+
+    expect(() => guard.checkPath('/Users/g/work/app/a.ts')).toThrow(CorpusLeakError);
+    expect(() => guard.checkPath('/Users/g/oss/lib/b.ts')).toThrow(CorpusLeakError);
+    expect(() => guard.checkPath('/Users/g/other/c.ts')).not.toThrow();
+  });
+
+  it('error message includes blocked path', () => {
+    const guard = new UploadGuard(['/corpus']);
+
+    try {
+      guard.checkPath('/corpus/secret.ts');
+      expect.fail('should have thrown');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(CorpusLeakError);
+      expect(err.message).toContain('/corpus/secret.ts');
+      expect(err.message).toContain('Corpus path blocked');
+    }
+  });
+});

--- a/test/corpus/UploadGuard.test.ts
+++ b/test/corpus/UploadGuard.test.ts
@@ -42,6 +42,22 @@ describe('UploadGuard', () => {
     expect(() => guard.checkPath('/Users/g/other/c.ts')).not.toThrow();
   });
 
+  it('does not block paths sharing a prefix but in a different directory', () => {
+    const guard = new UploadGuard(['/data/project']);
+
+    expect(() => {
+      guard.checkPath('/data/project-unrelated/file.ts');
+    }).not.toThrow();
+  });
+
+  it('blocks the exact corpus root path itself', () => {
+    const guard = new UploadGuard(['/data/project']);
+
+    expect(() => {
+      guard.checkPath('/data/project');
+    }).toThrow(CorpusLeakError);
+  });
+
   it('error message includes blocked path', () => {
     const guard = new UploadGuard(['/corpus']);
 

--- a/test/corpus/schema.test.ts
+++ b/test/corpus/schema.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+
+describe('corpus_chunks table schema', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS corpus_chunks (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        chunk_text TEXT NOT NULL,
+        embedding BLOB,
+        commit_hash TEXT,
+        indexed_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_corpus_chunks_project ON corpus_chunks(project_id);
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates corpus_chunks table', () => {
+    const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='corpus_chunks'").get() as any;
+    expect(row).toBeDefined();
+    expect(row.name).toBe('corpus_chunks');
+  });
+
+  it('has all required columns', () => {
+    const cols = (db.prepare("PRAGMA table_info(corpus_chunks)").all() as any[]).map(c => c.name);
+    expect(cols).toContain('id');
+    expect(cols).toContain('project_id');
+    expect(cols).toContain('source_path');
+    expect(cols).toContain('chunk_text');
+    expect(cols).toContain('embedding');
+    expect(cols).toContain('commit_hash');
+    expect(cols).toContain('indexed_at');
+  });
+
+  it('has project_id index', () => {
+    const idx = db.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_corpus_chunks_project'").get() as any;
+    expect(idx).toBeDefined();
+  });
+
+  it('inserts and retrieves a chunk', () => {
+    db.prepare(`
+      INSERT INTO corpus_chunks (id, project_id, source_path, chunk_text, commit_hash, indexed_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run('chunk-1', 'proj-1', '/src/foo.ts', 'const x = 1;', 'abc123', Date.now());
+
+    const row = db.prepare('SELECT * FROM corpus_chunks WHERE id = ?').get('chunk-1') as any;
+    expect(row.project_id).toBe('proj-1');
+    expect(row.source_path).toBe('/src/foo.ts');
+    expect(row.chunk_text).toBe('const x = 1;');
+  });
+});


### PR DESCRIPTION
## Summary

Build a local-only corpus RAG layer that indexes project workspaces (git history, source files, docs), retrieves top-K chunks at task-generation time, and injects traceable KB citations into every generated Archon task. Includes a freshness guard that blocks dispatch when the index is stale, and a deny-list preventing corpus data from leaking to NotebookLM uploads.

Implements #22

## Changes

| File | Action | Description |
|------|--------|-------------|
| `electron/corpus/corpus.config.ts` | CREATE | Corpus configuration schema with defaults (roots, chunk size, deny patterns) |
| `electron/corpus/CorpusIndexer.ts` | CREATE | Chunks files + git history, generates embeddings, upserts to SQLite |
| `electron/corpus/CorpusRetriever.ts` | CREATE | Cosine-similarity top-K chunk retrieval |
| `electron/corpus/CorpusFreshnessGuard.ts` | CREATE | Blocks task dispatch when corpus index is >2h behind HEAD |
| `electron/corpus/CorpusWatcher.ts` | CREATE | Daemon with debounced fs.watch + 5-min git poll for incremental re-index |
| `electron/corpus/TaskGeneratorContext.ts` | CREATE | Injects retrieved corpus chunks as citations into task system prompts |
| `electron/corpus/UploadGuard.ts` | CREATE | Deny-list enforcement preventing corpus data in NotebookLM uploads |
| `electron/corpus/index.ts` | CREATE | Barrel export for corpus module |
| `electron/db/DatabaseManager.ts` | UPDATE | Added `corpus_chunks` table schema in migrations |
| `electron/main.ts` | UPDATE | Wired CorpusWatcher into AppState service registry |

## Tests

| Test File | Tests |
|-----------|-------|
| `test/corpus/schema.test.ts` | Table creation, column validation, index check, insert/retrieve (4 tests) |
| `test/corpus/CorpusIndexer.test.ts` | Chunk splitting, file indexing, embedding, size limits, error handling (7 tests) |
| `test/corpus/CorpusRetriever.test.ts` | Top-K retrieval, empty project, embedding-less chunks (3 tests) |
| `test/corpus/CorpusFreshnessGuard.test.ts` | Stale detection (no chunks, old, recent, per-project) (4 tests) |
| `test/corpus/CorpusWatcher.test.ts` | File change trigger, clean stop (2 tests) |
| `test/corpus/TaskGeneratorContext.test.ts` | Prompt injection, empty state, commit hash, stale warning (4 tests) |
| `test/corpus/UploadGuard.test.ts` | Deny-list enforcement, allow paths, payload check, multi-root (6 tests) |

## Validation

- [x] Type check passes (frontend + electron)
- [ ] Lint — N/A (no ESLint config)
- [ ] Format — N/A (no Prettier config)
- [x] All tests pass (59 tests across 12 files)
- [x] Build succeeds

## Implementation Notes

### Deviations from Plan

1. **Paths remapped from `src/` to `electron/corpus/`** — Plan specified `src/` paths, but main process code lives under `electron/`. New module cleanly organized at `electron/corpus/`.
2. **Inline schema instead of SQL migration file** — No numbered migration system exists; followed existing pattern of inline `CREATE TABLE IF NOT EXISTS` in DatabaseManager.
3. **`child_process` instead of `simple-git`** — Avoids adding a new dependency; git CLI provides the same functionality.
4. **Tasks 7 & 8 are new files** — No existing `TaskGeneratorContext` or `UploadUtility` to modify; created fresh.
5. **Test directory `test/` not `tests/`** — Matches existing vitest configuration.

---

**Plan**: `docs/superpowers/plans/2026-04-22-issue-22-local-corpus-rag-plan.md`
**Workflow ID**: `f4f71a3d59d4e467dc839693ba9d29e9`
