### PR TITLE
Feat: wire personal memory graph end-to-end (#16)

### DIFF
--- a/electron/ipc/memoryHandlers.ts
+++ b/electron/ipc/memoryHandlers.ts
@@ -1,0 +1,31 @@
+import { ipcMain } from 'electron';
+import { MemoryManager } from '../memory/MemoryManager';
+import { NodeKind } from '../memory/schema';
+
+export function registerMemoryHandlers(): void {
+  const mm = () => MemoryManager.getInstance();
+
+  ipcMain.handle('memory:get-nodes', (_event, kind?: NodeKind, labelLike?: string) => {
+    return mm().findNodes(kind, labelLike);
+  });
+
+  ipcMain.handle('memory:get-edges-from', (_event, nodeId: string) => {
+    return mm().getEdgesFrom(nodeId);
+  });
+
+  ipcMain.handle('memory:get-edges-to', (_event, nodeId: string) => {
+    return mm().getEdgesTo(nodeId);
+  });
+
+  ipcMain.handle('memory:get-facts', (_event, nodeId: string) => {
+    return mm().getFacts(nodeId);
+  });
+
+  ipcMain.handle('memory:pending-review', () => {
+    return mm().getPendingReview();
+  });
+
+  ipcMain.handle('memory:resolve-review', (_event, id: number, approved: boolean) => {
+    return mm().resolveReview(id, approved);
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -85,6 +85,7 @@ import { DatabaseManager } from "./db/DatabaseManager"
 import { CredentialsManager } from "./services/CredentialsManager"
 import { ReleaseNotesManager } from "./update/ReleaseNotesManager"
 import { MemoryManager } from "./memory"
+import { registerMemoryHandlers } from "./ipc/memoryHandlers"
 import { IpcEventBus } from "./services/IpcEventBus"
 import { LunrIndexer } from "./services/LunrIndexer"
 import { SlidingWindowAnalyzer } from "./services/SlidingWindowAnalyzer"
@@ -204,6 +205,9 @@ export class AppState {
 
     // Initialize MemoryManager (separate memory.db for graph + facts)
     this.memoryManager = MemoryManager.getInstance()
+
+    // Register IPC handlers for memory graph queries
+    registerMemoryHandlers()
 
     // Initialize Corpus Watcher (local corpus RAG indexing)
     this.initializeCorpusWatcher()

--- a/electron/memory/RelationExtractor.ts
+++ b/electron/memory/RelationExtractor.ts
@@ -24,11 +24,11 @@ const EXTRACTION_SYSTEM_PROMPT = `You are a relation extractor for a personal kn
 Given a transcript snippet, extract structured triples (subject → predicate → object).
 
 Return a JSON array of objects with these fields:
-- sourceKind: one of "person", "topic", "organization", "project", "meeting", "decision"
+- sourceKind: one of "person", "topic", "organization", "project", "meeting", "decision", "goal", "commitment"
 - sourceLabel: human-readable name
 - targetKind: same options as sourceKind
 - targetLabel: human-readable name
-- predicate: one of "knows", "works_on", "belongs_to", "agreed_with", "owes", "discussed", "decided"
+- predicate: one of "knows", "works_on", "belongs_to", "agreed_with", "owes", "discussed", "decided", "reports_to", "blocked_by", "contradicts", "prefers"
 - confidence: number between 0 and 1
 - context: the exact snippet that supports this triple
 

--- a/electron/memory/schema.ts
+++ b/electron/memory/schema.ts
@@ -5,7 +5,7 @@
  * Node kinds allowed in the memory graph.
  * Extensible: add new literal members as needed.
  */
-export type NodeKind = 'person' | 'topic' | 'organization' | 'project' | 'meeting' | 'decision' | 'goal';
+export type NodeKind = 'person' | 'topic' | 'organization' | 'project' | 'meeting' | 'decision' | 'goal' | 'commitment';
 
 /**
  * Predicate labels for typed edges between nodes.
@@ -17,7 +17,11 @@ export type EdgePredicate =
   | 'agreed_with'
   | 'owes'
   | 'discussed'
-  | 'decided';
+  | 'decided'
+  | 'reports_to'
+  | 'blocked_by'
+  | 'contradicts'
+  | 'prefers';
 
 export interface MemoryNode {
   id: string;          // UUID

--- a/electron/services/MemoryGraphWriter.ts
+++ b/electron/services/MemoryGraphWriter.ts
@@ -1,5 +1,14 @@
 import { IpcEventBus, DecisionCapturedEvent } from "./IpcEventBus";
-import { DatabaseManager } from "../db/DatabaseManager";
+import { MemoryManager } from "../memory/MemoryManager";
+import { NodeKind, EdgePredicate } from "../memory/schema";
+
+// Map event type to edge predicate
+const TYPE_TO_PREDICATE: Record<DecisionCapturedEvent['type'], { sourceKind: NodeKind; targetKind: NodeKind; predicate: EdgePredicate }> = {
+  ownership:   { sourceKind: 'person', targetKind: 'project',    predicate: 'works_on'  },
+  commitment:  { sourceKind: 'person', targetKind: 'commitment', predicate: 'owes'      },
+  deadline:    { sourceKind: 'person', targetKind: 'commitment', predicate: 'owes'      },
+  unresolved:  { sourceKind: 'person', targetKind: 'decision',   predicate: 'discussed' },
+};
 
 export class MemoryGraphWriter {
   private handler: (e: DecisionCapturedEvent) => void;
@@ -12,22 +21,25 @@ export class MemoryGraphWriter {
   destroy(): void {
     IpcEventBus.offTyped("decision:captured", this.handler);
   }
+
   private write(e: DecisionCapturedEvent): void {
     try {
-      const db = DatabaseManager.getInstance().getDb();
-      if (!db) return;
-      // Guard: no-op if memory graph tables haven't been created yet (e.g., MemoryManager init failed)
-      const tableExists = db
-        .prepare(
-          "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_nodes'"
-        )
-        .get();
-      if (!tableExists) return;
-      // TODO: wire MemoryManager.proposeEdge() here — schema exists (memory_nodes/memory_edges),
-      // but write path deferred pending end-to-end integration testing of the decision capture pipeline.
-      console.log(
-        `[MemoryGraphWriter] Queued low-confidence relation: ${e.type} by ${e.speaker}`
+      const mm = MemoryManager.getInstance();
+      const mapping = TYPE_TO_PREDICATE[e.type];
+      if (!mapping) return;
+
+      const source = mm.upsertNode(mapping.sourceKind, e.speaker);
+      const target = mm.upsertNode(mapping.targetKind, e.text_excerpt.slice(0, 120));
+
+      const result = mm.proposeEdge(
+        source.id,
+        target.id,
+        mapping.predicate,
+        e.confidence,
+        e.meeting_id,
+        e.text_excerpt,
       );
+      console.log(`[MemoryGraphWriter] ${result.stored}: ${mapping.predicate} by ${e.speaker} (conf=${e.confidence})`);
     } catch (err) {
       console.warn('[MemoryGraphWriter] write skipped (DB unavailable):', err);
     }

--- a/electron/services/PostMeetingProcessor.ts
+++ b/electron/services/PostMeetingProcessor.ts
@@ -1,6 +1,8 @@
 import Database from 'better-sqlite3';
 import { DecisionLedger } from './DecisionLedger';
 import { GoalAligner } from './GoalAligner';
+import { extractRelations, LLMFn } from '../memory/RelationExtractor';
+import { MemoryManager } from '../memory/MemoryManager';
 
 export interface ExtractedDecision {
   text: string;
@@ -14,31 +16,40 @@ export interface DecisionExtractor {
 
 /**
  * Post-meeting processor: extracts decisions from a transcript,
- * aligns them to goals, and appends to the decision ledger.
+ * aligns them to goals, appends to the decision ledger,
+ * and extracts relation triples into the memory graph.
  */
 export class PostMeetingProcessor {
   private static instance: PostMeetingProcessor | undefined;
   private ledger: DecisionLedger;
   private aligner: GoalAligner;
   private extractor: DecisionExtractor;
+  private llmFn: LLMFn | null;
+  private memoryManager: MemoryManager | null;
 
   private constructor(
     ledger: DecisionLedger,
     aligner: GoalAligner,
     extractor: DecisionExtractor,
+    llmFn?: LLMFn,
+    memoryManager?: MemoryManager,
   ) {
     this.ledger = ledger;
     this.aligner = aligner;
     this.extractor = extractor;
+    this.llmFn = llmFn ?? null;
+    this.memoryManager = memoryManager ?? null;
   }
 
   public static getInstance(
     ledger: DecisionLedger,
     aligner: GoalAligner,
     extractor: DecisionExtractor,
+    llmFn?: LLMFn,
+    memoryManager?: MemoryManager,
   ): PostMeetingProcessor {
     if (!PostMeetingProcessor.instance) {
-      PostMeetingProcessor.instance = new PostMeetingProcessor(ledger, aligner, extractor);
+      PostMeetingProcessor.instance = new PostMeetingProcessor(ledger, aligner, extractor, llmFn, memoryManager);
     }
     return PostMeetingProcessor.instance;
   }
@@ -48,7 +59,8 @@ export class PostMeetingProcessor {
   }
 
   /**
-   * Process a meeting transcript: extract decisions, align to goals, write to ledger.
+   * Process a meeting transcript: extract decisions, align to goals, write to ledger,
+   * then extract relation triples into the memory graph.
    * Returns the number of decisions written.
    */
   public async run(meetingId: string, transcript: string): Promise<number> {
@@ -75,6 +87,15 @@ export class PostMeetingProcessor {
         if (result) written++;
       } catch (err) {
         console.error('[PostMeetingProcessor] Failed to persist decision:', decision.text.slice(0, 80), err);
+      }
+    }
+
+    // Extract relation triples into the memory graph
+    if (this.llmFn && this.memoryManager) {
+      try {
+        await extractRelations(transcript, meetingId, this.llmFn, this.memoryManager);
+      } catch (err) {
+        console.error('[PostMeetingProcessor] Relation extraction failed:', err);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "keytar": "^7.9.0",
     "lucide-react": "^0.460.0",
     "lunr": "^2.3.9",
+    "minimatch": "^10.2.5",
     "openai": "^6.19.0",
     "react": "^18.3.1",
     "react-code-blocks": "^0.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       lunr:
         specifier: ^2.3.9
         version: 2.3.9
+      minimatch:
+        specifier: ^10.2.5
+        version: 10.2.5
       openai:
         specifier: ^6.19.0
         version: 6.34.0(ws@8.20.0)(zod@3.24.3)
@@ -4505,10 +4508,6 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -8549,7 +8548,7 @@ snapshots:
       js-yaml: 4.1.0
       json5: 2.2.3
       lazy-val: 1.0.5
-      minimatch: 10.0.1
+      minimatch: 10.2.5
       resedit: 1.7.2
       sanitize-filename: 1.6.3
       semver: 7.7.1
@@ -9862,7 +9861,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.0
-      minimatch: 10.0.1
+      minimatch: 10.2.5
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
@@ -11092,10 +11091,6 @@ snapshots:
   mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
-
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
 
   minimatch@10.2.5:
     dependencies:

--- a/test/ipc/memoryHandlers.test.ts
+++ b/test/ipc/memoryHandlers.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { MemoryManager } from '../../electron/memory/MemoryManager';
+
+// Collect registered ipcMain handlers
+const handlers = new Map<string, (...args: any[]) => any>();
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: any[]) => any) => {
+      handlers.set(channel, handler);
+    },
+  },
+  app: {
+    getPath: () => '/tmp/cluely-test',
+  },
+}));
+
+import { registerMemoryHandlers } from '../../electron/ipc/memoryHandlers';
+
+describe('memoryHandlers', () => {
+  let db: Database.Database;
+  let mm: MemoryManager;
+
+  beforeEach(() => {
+    handlers.clear();
+    MemoryManager.resetInstance();
+    db = new Database(':memory:');
+    mm = MemoryManager.getInstance(db);
+    registerMemoryHandlers();
+  });
+
+  afterEach(() => {
+    db.close();
+    MemoryManager.resetInstance();
+  });
+
+  it('registers all 6 IPC channels', () => {
+    expect(handlers.has('memory:get-nodes')).toBe(true);
+    expect(handlers.has('memory:get-edges-from')).toBe(true);
+    expect(handlers.has('memory:get-edges-to')).toBe(true);
+    expect(handlers.has('memory:get-facts')).toBe(true);
+    expect(handlers.has('memory:pending-review')).toBe(true);
+    expect(handlers.has('memory:resolve-review')).toBe(true);
+  });
+
+  it('memory:get-nodes delegates to findNodes', () => {
+    mm.upsertNode('person', 'Alice');
+    mm.upsertNode('topic', 'GraphQL');
+
+    const result = handlers.get('memory:get-nodes')!({}, 'person');
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('Alice');
+  });
+
+  it('memory:get-nodes with no args returns all nodes', () => {
+    mm.upsertNode('person', 'Alice');
+    mm.upsertNode('topic', 'GraphQL');
+
+    const result = handlers.get('memory:get-nodes')!({});
+    expect(result).toHaveLength(2);
+  });
+
+  it('memory:get-edges-from delegates to getEdgesFrom', () => {
+    const a = mm.upsertNode('person', 'Alice');
+    const b = mm.upsertNode('project', 'App');
+    mm.proposeEdge(a.id, b.id, 'works_on', 0.9);
+
+    const result = handlers.get('memory:get-edges-from')!({}, a.id);
+    expect(result).toHaveLength(1);
+    expect(result[0].predicate).toBe('works_on');
+  });
+
+  it('memory:get-edges-to delegates to getEdgesTo', () => {
+    const a = mm.upsertNode('person', 'Alice');
+    const b = mm.upsertNode('project', 'App');
+    mm.proposeEdge(a.id, b.id, 'works_on', 0.9);
+
+    const result = handlers.get('memory:get-edges-to')!({}, b.id);
+    expect(result).toHaveLength(1);
+  });
+
+  it('memory:get-facts delegates to getFacts', () => {
+    const a = mm.upsertNode('person', 'Alice');
+    mm.upsertFact(a.id, 'email', 'alice@example.com');
+
+    const result = handlers.get('memory:get-facts')!({}, a.id);
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe('alice@example.com');
+  });
+
+  it('memory:pending-review delegates to getPendingReview', () => {
+    const a = mm.upsertNode('person', 'Alice');
+    const b = mm.upsertNode('person', 'Bob');
+    mm.proposeEdge(a.id, b.id, 'knows', 0.3, null, 'low confidence');
+
+    const result = handlers.get('memory:pending-review')!({});
+    expect(result).toHaveLength(1);
+    expect(result[0].confidence).toBe(0.3);
+  });
+
+  it('memory:resolve-review delegates to resolveReview', () => {
+    const a = mm.upsertNode('person', 'Alice');
+    const b = mm.upsertNode('person', 'Bob');
+    mm.proposeEdge(a.id, b.id, 'knows', 0.3, null, 'test');
+
+    const pending = mm.getPendingReview();
+    const result = handlers.get('memory:resolve-review')!({}, pending[0].id, true);
+    expect(result).toEqual({ resolved: true });
+
+    // After approval, should appear as an edge
+    const edges = mm.getEdgesFrom(a.id);
+    expect(edges).toHaveLength(1);
+  });
+});

--- a/test/memory/schemaTypes.test.ts
+++ b/test/memory/schemaTypes.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import type { NodeKind, EdgePredicate } from '../../electron/memory/schema';
+
+describe('schema types', () => {
+  it('NodeKind includes commitment', () => {
+    const kind: NodeKind = 'commitment';
+    expect(kind).toBe('commitment');
+  });
+
+  it('NodeKind includes all expected values', () => {
+    const kinds: NodeKind[] = ['person', 'topic', 'organization', 'project', 'meeting', 'decision', 'goal', 'commitment'];
+    expect(kinds).toHaveLength(8);
+  });
+
+  it('EdgePredicate includes new predicates', () => {
+    const predicates: EdgePredicate[] = ['reports_to', 'blocked_by', 'contradicts', 'prefers'];
+    expect(predicates).toHaveLength(4);
+  });
+
+  it('EdgePredicate includes all expected values', () => {
+    const predicates: EdgePredicate[] = [
+      'knows', 'works_on', 'belongs_to', 'agreed_with', 'owes',
+      'discussed', 'decided', 'reports_to', 'blocked_by', 'contradicts', 'prefers',
+    ];
+    expect(predicates).toHaveLength(11);
+  });
+});

--- a/test/services/MemoryGraphWriter.test.ts
+++ b/test/services/MemoryGraphWriter.test.ts
@@ -1,118 +1,124 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { IpcEventBus } from '../../electron/services/IpcEventBus';
-
-// Mock DatabaseManager before importing MemoryGraphWriter
-const mockGet = vi.fn();
-const mockPrepare = vi.fn(() => ({ get: mockGet }));
-const mockDb = { prepare: mockPrepare };
-
-vi.mock('../../electron/db/DatabaseManager', () => ({
-  DatabaseManager: {
-    getInstance: () => ({
-      getDb: () => mockDb,
-    }),
-  },
-}));
-
+import Database from 'better-sqlite3';
+import { IpcEventBus, DecisionCapturedEvent } from '../../electron/services/IpcEventBus';
+import { MemoryManager } from '../../electron/memory/MemoryManager';
 import { MemoryGraphWriter } from '../../electron/services/MemoryGraphWriter';
 
 describe('MemoryGraphWriter', () => {
   let writer: MemoryGraphWriter;
+  let db: Database.Database;
+  let mm: MemoryManager;
 
   beforeEach(() => {
-    mockGet.mockReset();
-    mockPrepare.mockClear();
+    MemoryManager.resetInstance();
+    db = new Database(':memory:');
+    mm = MemoryManager.getInstance(db);
     writer = new MemoryGraphWriter();
   });
 
   afterEach(() => {
     writer.destroy();
+    db.close();
+    MemoryManager.resetInstance();
   });
 
-  it('subscribes to decision:captured on construction', () => {
-    const spy = vi.fn();
-    const w = new MemoryGraphWriter();
-    // Emit event — should not throw
+  function emitDecision(overrides: Partial<DecisionCapturedEvent> = {}) {
     IpcEventBus.emitTyped('decision:captured', {
-      type: 'action-item',
+      type: 'commitment',
       speaker: 'Alice',
-      text: 'will send report',
-      confidence: 0.6,
+      timestamp: Date.now(),
+      text_excerpt: 'will send the report by Friday',
+      confidence: 0.8,
+      meeting_id: 'meeting-1',
+      turn_id: 'turn-1',
+      ...overrides,
     });
-    w.destroy();
+  }
+
+  it('calls proposeEdge for a commitment event', () => {
+    const spy = vi.spyOn(mm, 'proposeEdge');
+    emitDecision({ type: 'commitment', confidence: 0.8 });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'owes',
+      0.8,
+      'meeting-1',
+      'will send the report by Friday',
+    );
+  });
+
+  it('creates person and commitment nodes via upsertNode', () => {
+    emitDecision({ type: 'commitment', speaker: 'Bob' });
+
+    const people = mm.findNodes('person', 'Bob');
+    expect(people).toHaveLength(1);
+
+    const commitments = mm.findNodes('commitment');
+    expect(commitments).toHaveLength(1);
+  });
+
+  it('routes high-confidence event to edges table', () => {
+    emitDecision({ type: 'ownership', confidence: 0.9, speaker: 'Carol' });
+
+    const person = mm.findNodes('person', 'Carol')[0];
+    const edges = mm.getEdgesFrom(person.id);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].predicate).toBe('works_on');
+  });
+
+  it('routes low-confidence event to pending_review', () => {
+    emitDecision({ type: 'deadline', confidence: 0.5 });
+
+    const pending = mm.getPendingReview();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].predicate).toBe('owes');
+    expect(pending[0].confidence).toBe(0.5);
+  });
+
+  it('maps unresolved type to discussed predicate', () => {
+    const spy = vi.spyOn(mm, 'proposeEdge');
+    emitDecision({ type: 'unresolved', confidence: 0.75 });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'discussed',
+      0.75,
+      'meeting-1',
+      expect.any(String),
+    );
   });
 
   it('unsubscribes on destroy', () => {
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    mockGet.mockReturnValue({ name: 'memory_nodes' });
-
+    const spy = vi.spyOn(mm, 'proposeEdge');
     writer.destroy();
 
-    // Emitting after destroy should not trigger any DB call
-    mockPrepare.mockClear();
-    IpcEventBus.emitTyped('decision:captured', {
-      type: 'action-item',
-      speaker: 'Bob',
-      text: 'test',
-      confidence: 0.5,
-    });
+    emitDecision();
 
-    expect(mockPrepare).not.toHaveBeenCalled();
-    consoleSpy.mockRestore();
+    expect(spy).not.toHaveBeenCalled();
   });
 
-  it('skips write when memory_nodes table does not exist', () => {
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    mockGet.mockReturnValue(undefined);
-
-    IpcEventBus.emitTyped('decision:captured', {
-      type: 'action-item',
-      speaker: 'Alice',
-      text: 'do the thing',
-      confidence: 0.7,
-    });
-
-    expect(mockPrepare).toHaveBeenCalled();
-    expect(consoleSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining('Queued low-confidence relation'),
-    );
-    consoleSpy.mockRestore();
-  });
-
-  it('logs queued relation when table exists', () => {
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    mockGet.mockReturnValue({ name: 'memory_nodes' });
-
-    IpcEventBus.emitTyped('decision:captured', {
-      type: 'follow-up',
-      speaker: 'Charlie',
-      text: 'schedule sync',
-      confidence: 0.8,
-    });
-
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Queued low-confidence relation: follow-up by Charlie'),
-    );
-    consoleSpy.mockRestore();
-  });
-
-  it('handles DB unavailable gracefully', () => {
+  it('handles MemoryManager errors gracefully', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    mockPrepare.mockImplementation(() => {
-      throw new Error('DB locked');
-    });
+    vi.spyOn(mm, 'upsertNode').mockImplementation(() => { throw new Error('DB locked'); });
 
-    IpcEventBus.emitTyped('decision:captured', {
-      type: 'action-item',
-      speaker: 'Dan',
-      text: 'fix bug',
-      confidence: 0.9,
-    });
+    emitDecision();
 
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('write skipped'),
       expect.any(Error),
     );
     warnSpy.mockRestore();
+  });
+
+  it('truncates long text_excerpt for target label', () => {
+    const longText = 'a'.repeat(200);
+    emitDecision({ text_excerpt: longText });
+
+    const commitments = mm.findNodes('commitment');
+    expect(commitments).toHaveLength(1);
+    expect(commitments[0].label).toHaveLength(120);
   });
 });

--- a/test/services/PostMeetingProcessorElectron.test.ts
+++ b/test/services/PostMeetingProcessorElectron.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { MemoryManager } from '../../electron/memory/MemoryManager';
+import { PostMeetingProcessor, DecisionExtractor } from '../../electron/services/PostMeetingProcessor';
+import { DecisionLedger } from '../../electron/services/DecisionLedger';
+import { GoalAligner } from '../../electron/memory/GoalAligner';
+import { LLMFn } from '../../electron/memory/RelationExtractor';
+
+// Minimal stubs for DecisionLedger and GoalAligner
+function makeLedgerStub() {
+  return {
+    append: vi.fn().mockReturnValue(true),
+  } as unknown as DecisionLedger;
+}
+
+function makeAlignerStub() {
+  return {
+    align: vi.fn().mockResolvedValue(null),
+  } as unknown as GoalAligner;
+}
+
+function makeExtractorStub(): DecisionExtractor {
+  return {
+    extractDecisions: vi.fn().mockResolvedValue([
+      { text: 'Ship v2 by Friday', speaker: 'Alice', timestamp: '00:10' },
+    ]),
+  };
+}
+
+describe('PostMeetingProcessor (electron) — relation extraction', () => {
+  let db: Database.Database;
+  let mm: MemoryManager;
+
+  beforeEach(() => {
+    MemoryManager.resetInstance();
+    PostMeetingProcessor.resetInstance();
+    db = new Database(':memory:');
+    mm = MemoryManager.getInstance(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    MemoryManager.resetInstance();
+    PostMeetingProcessor.resetInstance();
+  });
+
+  it('calls extractRelations after decision extraction when llmFn is provided', async () => {
+    const llmFn: LLMFn = vi.fn().mockResolvedValue(JSON.stringify([
+      {
+        sourceKind: 'person',
+        sourceLabel: 'Alice',
+        targetKind: 'commitment',
+        targetLabel: 'Ship v2',
+        predicate: 'owes',
+        confidence: 0.85,
+        context: 'Alice will ship v2',
+      },
+    ]));
+
+    const processor = PostMeetingProcessor.getInstance(
+      makeLedgerStub(),
+      makeAlignerStub(),
+      makeExtractorStub(),
+      llmFn,
+      mm,
+    );
+
+    await processor.run('meeting-1', 'Alice said she will ship v2 by Friday');
+
+    expect(llmFn).toHaveBeenCalledWith(
+      expect.stringContaining('commitment'),
+      'Alice said she will ship v2 by Friday',
+    );
+
+    // Verify node was created
+    const people = mm.findNodes('person', 'Alice');
+    expect(people).toHaveLength(1);
+
+    // Verify edge was created (confidence 0.85 > 0.7 gate)
+    const edges = mm.getEdgesFrom(people[0].id);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].predicate).toBe('owes');
+  });
+
+  it('does not call extractRelations when llmFn is not provided', async () => {
+    const processor = PostMeetingProcessor.getInstance(
+      makeLedgerStub(),
+      makeAlignerStub(),
+      makeExtractorStub(),
+    );
+
+    const written = await processor.run('meeting-1', 'some transcript');
+
+    expect(written).toBe(1);
+    // No relation nodes should exist
+    const nodes = mm.findNodes();
+    expect(nodes).toHaveLength(0);
+  });
+
+  it('handles extractRelations failure gracefully', async () => {
+    const llmFn: LLMFn = vi.fn().mockRejectedValue(new Error('LLM timeout'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const processor = PostMeetingProcessor.getInstance(
+      makeLedgerStub(),
+      makeAlignerStub(),
+      makeExtractorStub(),
+      llmFn,
+      mm,
+    );
+
+    const written = await processor.run('meeting-1', 'some transcript');
+
+    // Decisions should still be written even if relation extraction fails
+    expect(written).toBe(1);
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Completes the end-to-end wiring of the personal memory graph introduced in issue #16. The typed graph schema (`entities` + `relations` SQLite tables) and `MemoryManager` singleton already existed but were never populated — `MemoryGraphWriter` had a TODO where `proposeEdge` should be called, `PostMeetingProcessor` never invoked `extractRelations`, and no IPC channels exposed graph data to the renderer.

This PR resolves all four gaps:

- **Schema**: adds `commitment` to `NodeKind`; adds `reports_to`, `blocked_by`, `contradicts`, `prefers` to `EdgePredicate`
- **Extraction**: updates `RelationExtractor` system prompt to match the extended schema; adds `extractRelations` call to `PostMeetingProcessor.run()` after decision extraction
- **Persistence**: replaces the TODO in `MemoryGraphWriter.write()` with real `MemoryManager.upsertNode()` + `proposeEdge()` calls, mapping `DecisionCapturedEvent` types to graph edges
- **Query API**: creates `electron/ipc/memoryHandlers.ts` registering 6 IPC channels (`memory:get-nodes`, `memory:get-edges-from`, `memory:get-edges-to`, `memory:get-facts`, `memory:pending-review`, `memory:resolve-review`); registered in `AppState` constructor
- **Dependency fix**: declares `minimatch` as a direct dependency (pnpm strict mode blocked transitive access in `CorpusIndexer`)

## Changes

| File | Action |
|------|--------|
| `electron/memory/schema.ts` | Add `commitment` NodeKind + 4 new EdgePredicates |
| `electron/memory/RelationExtractor.ts` | Sync system prompt with extended schema |
| `electron/services/MemoryGraphWriter.ts` | Replace TODO with `proposeEdge` call; remove `DatabaseManager` dep |
| `electron/services/PostMeetingProcessor.ts` | Add optional `llmFn`/`memoryManager` params; call `extractRelations` in `run()` |
| `electron/ipc/memoryHandlers.ts` | CREATE — 6 IPC query handlers |
| `electron/main.ts` | Import + call `registerMemoryHandlers()` |
| `test/memory/schemaTypes.test.ts` | CREATE — type-level tests for new NodeKind/EdgePredicate values |
| `test/services/MemoryGraphWriter.test.ts` | Rewrite — use real in-memory SQLite; assert `proposeEdge` called |
| `test/services/PostMeetingProcessorElectron.test.ts` | CREATE — assert `extractRelations` called in `run()` |
| `test/ipc/memoryHandlers.test.ts` | CREATE — assert each handler delegates to correct `MemoryManager` method |
| `package.json` / `pnpm-lock.yaml` | Declare `minimatch` as direct dep |

## Key design decisions

- **`llmFn` and `memoryManager` are optional** in `PostMeetingProcessor` — existing callers in `main.ts` don't have an LLM function at construction time; relation extraction is skipped gracefully when not provided.
- **New `electron/ipc/` subdirectory** — `ipcHandlers.ts` lives at `electron/ipcHandlers.ts`; domain-specific handlers now live in `electron/ipc/` for clean separation.
- **No schema migration** — `commitment` is a TypeScript type only; the SQLite `memory_nodes.kind` column is TEXT with no CHECK constraint, so new values store transparently.

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` (src + electron) | ✅ 0 errors |
| New tests (23 tests, 4 files) | ✅ All passed |
| Full suite (`npx vitest run`) | ✅ 390 passed, 73 files, 0 failures |
| `npm run build` | ✅ Compiled in 14.84s |

## Out of scope

- Graph visualization UI (renderer components)
- Conflict detection integration (`ConflictDetector` wiring to `PostMeetingProcessor`)
- Approval UI for low-confidence edges (`pending_review`)
- Semantic/embedding-based graph search
- Graph pruning / decay triggers

Fixes #16