### PR TITLE
Feat: multi-project dispatch dashboard (#19)

### DIFF
--- a/electron/config/projectHealthEndpoints.json
+++ b/electron/config/projectHealthEndpoints.json
@@ -1,1 +1,8 @@
-{}
+{
+  "finbiz": { "type": "http", "url": "http://localhost:9101/health" },
+  "qualiaai": { "type": "http", "url": "http://localhost:9102/health" },
+  "ev0": { "type": "http", "url": "http://localhost:9103/health" },
+  "signal": { "type": "http", "url": "http://localhost:9104/health" },
+  "succession": { "type": "http", "url": "http://localhost:9105/health" },
+  "scraping-doctor": { "type": "http", "url": "http://localhost:9106/health" }
+}

--- a/electron/ipc/dashboardHandlers.ts
+++ b/electron/ipc/dashboardHandlers.ts
@@ -1,0 +1,52 @@
+import { getAllEndpoints } from '../config/HealthEndpointConfig';
+import { HealthChunkWriter } from '../services/HealthChunkWriter';
+import { DashboardPoller } from '../services/DashboardPoller';
+
+type SafeHandleRegistrar = {
+  safeHandle(channel: string, listener: (event: any, ...args: any[]) => Promise<any> | any): void;
+};
+
+export function registerDashboardHandlers(
+  registrar: SafeHandleRegistrar,
+  healthChunkWriter: HealthChunkWriter | null,
+  poller: DashboardPoller | null,
+): void {
+  registrar.safeHandle('dashboard:get-snapshots', async () => {
+    if (!healthChunkWriter) return [];
+    try {
+      const endpoints = getAllEndpoints();
+      const projectIds = Object.keys(endpoints);
+      const snapshots: Array<{ projectId: string; content: string; fetchedAt: string; stale: boolean }> = [];
+
+      for (const id of projectIds) {
+        const chunk = healthChunkWriter.getLatestChunk(id);
+        if (chunk) {
+          snapshots.push({
+            projectId: chunk.projectId,
+            content: chunk.content,
+            fetchedAt: chunk.fetchedAt,
+            stale: chunk.stale,
+          });
+        }
+      }
+
+      return snapshots;
+    } catch (err: any) {
+      console.error('[dashboardHandlers] get-snapshots failed:', err);
+      return { error: err.message };
+    }
+  });
+
+  registrar.safeHandle('dashboard:refresh', async () => {
+    if (!poller) return { success: false, error: 'Poller not initialized' };
+    try {
+      poller._runCycle().catch((err: any) => {
+        console.error('[dashboardHandlers] refresh cycle failed:', err);
+      });
+      return { success: true };
+    } catch (err: any) {
+      console.error('[dashboardHandlers] refresh failed:', err);
+      return { success: false, error: err.message };
+    }
+  });
+}

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -10,6 +10,7 @@ import * as fs from "fs";
 import { AudioDevices } from "./audio/AudioDevices";
 
 import { ENGLISH_VARIANTS } from "./config/languages"
+import { registerDashboardHandlers } from './ipc/dashboardHandlers';
 
 export function initializeIpcHandlers(appState: AppState): void {
   const safeHandle = (channel: string, listener: (event: any, ...args: any[]) => Promise<any> | any) => {
@@ -1917,4 +1918,11 @@ export function initializeIpcHandlers(appState: AppState): void {
     if (typeof query !== 'string' || !query.trim()) return [];
     return appState.getLunrIndexer().search(query);
   });
+
+  // Dispatch Dashboard handlers
+  registerDashboardHandlers(
+    { safeHandle },
+    appState.getHealthChunkWriter(),
+    appState.getDashboardPoller(),
+  );
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -100,6 +100,7 @@ import { AgentStateManager } from "./services/AgentStateManager"
 import { PermissionsAuditLog } from "./services/PermissionsAuditLog"
 import { CommitmentStalenessChecker, CommitmentQuerySource } from "./services/CommitmentStalenessChecker"
 import { BackgroundAgent } from "./services/BackgroundAgent"
+import { DashboardPoller } from './services/DashboardPoller'
 import { TokenUsageTracker } from "./services/TokenUsageTracker"
 import { getAgentConfig, setAgentIntervalMs } from "./config/agentConfig"
 
@@ -128,6 +129,8 @@ export class AppState {
   private memoryGraphWriter: MemoryGraphWriter = new MemoryGraphWriter()
   private agentStateManager: AgentStateManager = new AgentStateManager()
   private backgroundAgent: BackgroundAgent | null = null
+  private dashboardPoller: DashboardPoller | null = null
+  private _healthChunkWriter: import('./services/HealthChunkWriter').HealthChunkWriter | null = null
   private tokenUsageTracker: TokenUsageTracker = new TokenUsageTracker()
   private activeMeetingId: string = ''
   private turnCounter: number = 0
@@ -1198,6 +1201,14 @@ export class AppState {
     return this.backgroundAgent;
   }
 
+  public getDashboardPoller(): DashboardPoller | null {
+    return this.dashboardPoller;
+  }
+
+  public getHealthChunkWriter(): import('./services/HealthChunkWriter').HealthChunkWriter | null {
+    return this._healthChunkWriter;
+  }
+
   public getView(): "queue" | "solutions" {
     return this.view
   }
@@ -1921,6 +1932,22 @@ async function initializeApp() {
       console.error('[Main] Failed to start PreMeetingOrchestrator:', e);
     }
 
+    // Initialize DashboardPoller
+    try {
+      const { HealthChunkWriter: HCW } = require('./services/HealthChunkWriter');
+      const db = appState.getMemoryManager().getDb();
+      if (db) {
+        const healthWriter = new HCW(db);
+        appState['_healthChunkWriter'] = healthWriter;
+        const poller = new DashboardPoller(healthWriter);
+        appState['dashboardPoller'] = poller;
+        poller.start();
+        console.log('[Main] DashboardPoller started');
+      }
+    } catch (e) {
+      console.error('[Main] Failed to start DashboardPoller:', e);
+    }
+
     // Note: We do NOT force dock show here anymore, respecting stealth mode.
   })
 
@@ -1951,6 +1978,11 @@ async function initializeApp() {
       appState.getBackgroundAgent()?.stop();
     } catch (e) {
       console.error('[Main] Failed to stop BackgroundAgent:', e);
+    }
+    try {
+      appState.getDashboardPoller()?.stop();
+    } catch (e) {
+      console.error('[Main] Failed to stop DashboardPoller:', e);
     }
     try {
       MulticaManager.getInstance().stop();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -203,6 +203,13 @@ interface ElectronAPI {
     getLastBrief: () => Promise<any>;
   };
 
+  // Dispatch Dashboard
+  dashboard: {
+    getSnapshots: () => Promise<Array<{ projectId: string; content: string; fetchedAt: string; stale: boolean }>>;
+    refresh: () => Promise<{ success: boolean }>;
+    onSnapshotsUpdated: (cb: (snapshots: Array<{ projectId: string; content: string; fetchedAt: string; stale: boolean }>) => void) => () => void;
+  };
+
   // Goal Management
   goalCreate: (opts: { title: string; description?: string; parent_id?: string }) => Promise<{ id: string; title: string } | { error: string }>;
   goalList: () => Promise<Array<{ id: string; title: string; description: string; parent_id: string | null; created_at: number; completed_at: number | null }>>;
@@ -842,6 +849,17 @@ contextBridge.exposeInMainWorld("electronAPI", {
       return () => ipcRenderer.removeListener('pre-meeting:brief-ready', subscription);
     },
     getLastBrief: () => ipcRenderer.invoke('pre-meeting:get-last-brief'),
+  },
+
+  // Dispatch Dashboard API
+  dashboard: {
+    getSnapshots: () => ipcRenderer.invoke('dashboard:get-snapshots'),
+    refresh: () => ipcRenderer.invoke('dashboard:refresh'),
+    onSnapshotsUpdated: (cb: (snapshots: any[]) => void) => {
+      const subscription = (_: any, data: any) => cb(data);
+      ipcRenderer.on('dashboard:snapshots-updated', subscription);
+      return () => ipcRenderer.removeListener('dashboard:snapshots-updated', subscription);
+    },
   },
 
   // Goal Management API

--- a/electron/services/DashboardPoller.ts
+++ b/electron/services/DashboardPoller.ts
@@ -1,0 +1,98 @@
+import { BrowserWindow } from 'electron';
+import { getAllEndpoints } from '../config/HealthEndpointConfig';
+import { healthSnapshotFetcher, HealthSnapshot } from './HealthSnapshotFetcher';
+import { HealthChunkWriter } from './HealthChunkWriter';
+import { serializeSnapshot, serializeError } from './HealthSnapshotSerializer';
+
+export class DashboardPoller {
+  private timer: NodeJS.Timeout | null = null;
+  private _intervalMs: number;
+
+  constructor(
+    private healthChunkWriter: HealthChunkWriter,
+    intervalMs = 5 * 60_000,
+  ) {
+    this._intervalMs = intervalMs;
+  }
+
+  start(intervalMs?: number): void {
+    if (intervalMs !== undefined) this._intervalMs = intervalMs;
+    this.stop();
+    this._runCycle().catch(() => {});
+    this.timer = setInterval(() => this._runCycle(), this._intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  setInterval(ms: number): void {
+    this._intervalMs = ms;
+    if (this.timer) {
+      this.stop();
+      this.start();
+    }
+  }
+
+  getIntervalMs(): number {
+    return this._intervalMs;
+  }
+
+  async _runCycle(): Promise<void> {
+    const endpoints = getAllEndpoints();
+    const projectIds = Object.keys(endpoints);
+    const now = new Date().toISOString();
+
+    const results = await Promise.allSettled(
+      projectIds.map(id => healthSnapshotFetcher.fetchForProject(id)),
+    );
+
+    const snapshots: Array<{ projectId: string; content: string; fetchedAt: string; stale: boolean }> = [];
+
+    for (let i = 0; i < projectIds.length; i++) {
+      const id = projectIds[i];
+      const result = results[i];
+
+      let content: string;
+      let fetchedAt = now;
+
+      if (result.status === 'fulfilled' && result.value) {
+        const snapshot = result.value;
+        fetchedAt = snapshot.fetchedAt;
+        content = serializeSnapshot(snapshot);
+      } else {
+        const reason = result.status === 'rejected' ? String(result.reason) : 'no data';
+        content = serializeError(id, reason);
+      }
+
+      try {
+        this.healthChunkWriter.writeChunk(content, { projectId: id, fetchedAt });
+      } catch (err) {
+        console.warn(`[DashboardPoller] Failed to write chunk for ${id}:`, err);
+      }
+
+      const chunk = this.healthChunkWriter.getLatestChunk(id);
+      if (chunk) {
+        snapshots.push({
+          projectId: chunk.projectId,
+          content: chunk.content,
+          fetchedAt: chunk.fetchedAt,
+          stale: chunk.stale,
+        });
+      }
+    }
+
+    this.broadcast('dashboard:snapshots-updated', snapshots);
+  }
+
+  private broadcast(channel: string, data: unknown): void {
+    BrowserWindow.getAllWindows().forEach(win => {
+      if (!win.isDestroyed()) {
+        win.webContents.send(channel, data);
+      }
+    });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "keytar": "^7.9.0",
         "lucide-react": "^0.460.0",
         "lunr": "^2.3.9",
+        "minimatch": "^10.2.5",
         "openai": "^6.19.0",
         "react": "^18.3.1",
         "react-code-blocks": "^0.1.6",
@@ -1016,6 +1017,22 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@electron/universal/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -1516,48 +1533,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@eslint/config-helpers": {
@@ -4101,27 +4076,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/package-json/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@npmcli/package-json/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -4158,21 +4112,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@npmcli/package-json/node_modules/proc-log": {
@@ -4274,27 +4213,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/run-script/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/run-script/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@npmcli/run-script/node_modules/cacache": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
@@ -4363,21 +4281,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@npmcli/run-script/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@npmcli/run-script/node_modules/minipass-fetch": {
@@ -5594,27 +5497,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@sigstore/sign/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@sigstore/sign/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@sigstore/sign/node_modules/cacache": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
@@ -5683,21 +5565,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@sigstore/sign/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@sigstore/sign/node_modules/minipass-fetch": {
@@ -6217,27 +6084,6 @@
         "@tapjs/core": "4.5.1"
       }
     },
-    "node_modules/@tapjs/run/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@tapjs/run/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@tapjs/run/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -6274,21 +6120,6 @@
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@tapjs/run/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6411,27 +6242,6 @@
         "@tapjs/core": "4.5.1"
       }
     },
-    "node_modules/@tapjs/test/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@tapjs/test/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@tapjs/test/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -6441,21 +6251,6 @@
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@tapjs/test/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6593,42 +6388,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@tufjs/models/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@tufjs/models/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@tufjs/models/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@tweenjs/tween.js": {
@@ -7261,6 +7020,22 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -7967,29 +7742,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/app-builder-lib/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/app-builder-lib/node_modules/cacache": {
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
@@ -8200,22 +7952,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/app-builder-lib/node_modules/minipass": {
@@ -9357,6 +9093,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/cacache/node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -10208,6 +9960,22 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/config-file-ts/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/config-file-ts/node_modules/path-scurry": {
       "version": "1.11.1",
@@ -12165,31 +11933,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
@@ -12213,23 +11956,6 @@
       "peer": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/espree": {
@@ -13072,6 +12798,21 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/gaxios/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gaxios/node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -13502,6 +13243,21 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/google-gax/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/google-gax/node_modules/path-scurry": {
       "version": "1.11.1",
@@ -14292,42 +14048,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/imurmurhash": {
@@ -17044,18 +16764,39 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -17678,27 +17419,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm-registry-fetch/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm-registry-fetch/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/npm-registry-fetch/node_modules/cacache": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
@@ -17767,21 +17487,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm-registry-fetch/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-registry-fetch/node_modules/minipass-fetch": {
@@ -18147,27 +17852,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/pacote/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/pacote/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/pacote/node_modules/cacache": {
       "version": "20.0.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
@@ -18214,21 +17898,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/pacote/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pacote/node_modules/proc-log": {
@@ -19750,27 +19419,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/resolve-import/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/resolve-import/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/resolve-import/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -19780,21 +19428,6 @@
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/resolve-import/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -19899,27 +19532,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/rimraf/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -19929,21 +19541,6 @@
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -21291,27 +20888,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sync-content/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/sync-content/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/sync-content/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -21321,21 +20897,6 @@
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
         "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/sync-content/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -21844,6 +21405,21 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/test-exclude/node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -22217,27 +21793,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/tshy/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/tshy/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/tshy/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -22263,21 +21818,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/tshy/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tshy/node_modules/readdirp": {
@@ -22339,27 +21879,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/tuf-js/node_modules/balanced-match": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/tuf-js/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/tuf-js/node_modules/cacache": {
@@ -22430,21 +21949,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/tuf-js/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tuf-js/node_modules/minipass-fetch": {

--- a/src/components/DispatchDashboard.tsx
+++ b/src/components/DispatchDashboard.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useState } from 'react';
+import { RefreshCw, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface DashboardSnapshot {
+  projectId: string;
+  content: string;
+  fetchedAt: string;
+  stale: boolean;
+}
+
+function parseStatus(content: string): string {
+  const match = content.match(/\*\*Status:\*\*\s*(\S+)/);
+  return match?.[1] ?? 'unknown';
+}
+
+function countAlerts(content: string): number {
+  const section = content.split('## Alerts')[1];
+  if (!section) return 0;
+  return (section.match(/^- /gm) ?? []).length;
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case 'healthy':
+      return 'text-emerald-400';
+    case 'degraded':
+      return 'text-amber-400';
+    default:
+      return 'text-red-400';
+  }
+}
+
+function statusDot(status: string): string {
+  switch (status) {
+    case 'healthy':
+      return 'bg-emerald-400';
+    case 'degraded':
+      return 'bg-amber-400';
+    default:
+      return 'bg-red-400';
+  }
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.round(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  return `${hrs}h ago`;
+}
+
+export function DispatchDashboard() {
+  const [snapshots, setSnapshots] = useState<DashboardSnapshot[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api?.dashboard) return;
+
+    api.dashboard.getSnapshots().then((s: DashboardSnapshot[]) => {
+      if (Array.isArray(s)) setSnapshots(s);
+    }).catch((err: unknown) => {
+      console.warn('[DispatchDashboard] Failed to fetch snapshots:', err);
+    });
+
+    const cleanup = api.dashboard.onSnapshotsUpdated((s: DashboardSnapshot[]) => {
+      if (Array.isArray(s)) setSnapshots(s);
+    });
+    return cleanup;
+  }, []);
+
+  const handleRefresh = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      const api = (window as any).electronAPI;
+      await api?.dashboard?.refresh();
+    } catch {
+      // ignore
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {!dismissed && snapshots.length > 0 && (
+        <motion.div
+          key="dispatch-dashboard"
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          className="mx-4 mt-3 rounded-xl border border-violet-500/20 bg-violet-950/20 overflow-hidden"
+        >
+          <div className="flex items-center gap-2 px-3 py-2">
+            <span className="text-[9px] font-bold tracking-widest text-violet-400 uppercase shrink-0">
+              Dispatch
+            </span>
+            <span className="flex-1" />
+            <button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              className="shrink-0 text-text-tertiary hover:text-text-primary transition-colors disabled:opacity-50"
+              aria-label="Refresh"
+            >
+              <RefreshCw size={11} className={refreshing ? 'animate-spin' : ''} />
+            </button>
+            <button
+              onClick={() => setDismissed(true)}
+              className="shrink-0 text-text-tertiary hover:text-text-primary transition-colors"
+              aria-label="Dismiss"
+            >
+              <X size={11} />
+            </button>
+          </div>
+
+          <div className="px-3 pb-2.5 pt-1 space-y-1 border-t border-violet-500/10">
+            {snapshots.map(snap => {
+              const status = parseStatus(snap.content);
+              const alerts = countAlerts(snap.content);
+              return (
+                <div key={snap.projectId} className="flex items-center gap-2 text-[10px]">
+                  <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusDot(status)}`} />
+                  <span className="font-semibold text-violet-300/80 w-28 truncate">{snap.projectId}</span>
+                  <span className={`${statusColor(status)} w-16`}>{status}</span>
+                  {alerts > 0 && (
+                    <span className="text-amber-400">{alerts} alert{alerts > 1 ? 's' : ''}</span>
+                  )}
+                  {snap.stale && (
+                    <span className="text-text-tertiary bg-white/5 px-1 py-0.5 rounded text-[8px]">stale</span>
+                  )}
+                  <span className="text-text-tertiary ml-auto">{relativeTime(snap.fetchedAt)}</span>
+                </div>
+              );
+            })}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/test/components/DispatchDashboard.test.tsx
+++ b/test/components/DispatchDashboard.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import React from 'react';
+import { render, fireEvent, act, cleanup, waitFor } from '@testing-library/react';
+import { DispatchDashboard } from '../../src/components/DispatchDashboard';
+
+const mockGetSnapshots = vi.fn();
+const mockRefresh = vi.fn();
+const mockOnSnapshotsUpdated = vi.fn();
+
+const sampleSnapshots = [
+  {
+    projectId: 'finbiz',
+    content: '# Finbiz Health — 2026-05-01T10:00:00Z\n\n**Status:** healthy',
+    fetchedAt: new Date().toISOString(),
+    stale: false,
+  },
+  {
+    projectId: 'qualiaai',
+    content: '# Qualiaai Health — 2026-05-01T10:00:00Z\n\n**Status:** degraded\n\n## Alerts\n- High latency\n- Timeout',
+    fetchedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    stale: true,
+  },
+];
+
+describe('DispatchDashboard', () => {
+  beforeEach(() => {
+    mockGetSnapshots.mockResolvedValue(sampleSnapshots);
+    mockRefresh.mockResolvedValue({ success: true });
+    mockOnSnapshotsUpdated.mockReturnValue(() => {});
+
+    (window as any).electronAPI = {
+      dashboard: {
+        getSnapshots: mockGetSnapshots,
+        refresh: mockRefresh,
+        onSnapshotsUpdated: mockOnSnapshotsUpdated,
+      },
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    delete (window as any).electronAPI;
+  });
+
+  it('renders project cards from getSnapshots', async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<DispatchDashboard />);
+    });
+
+    expect(result!.getByText('finbiz')).toBeTruthy();
+    expect(result!.getByText('qualiaai')).toBeTruthy();
+  });
+
+  it('shows correct status text', async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<DispatchDashboard />);
+    });
+
+    expect(result!.getByText('healthy')).toBeTruthy();
+    expect(result!.getByText('degraded')).toBeTruthy();
+  });
+
+  it('shows stale indicator when stale is true', async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<DispatchDashboard />);
+    });
+
+    expect(result!.getByText('stale')).toBeTruthy();
+  });
+
+  it('shows alert count', async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<DispatchDashboard />);
+    });
+
+    expect(result!.getByText('2 alerts')).toBeTruthy();
+  });
+
+  it('calls refresh on Refresh button click', async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<DispatchDashboard />);
+    });
+
+    const refreshBtn = result!.getByLabelText('Refresh');
+    await act(async () => {
+      fireEvent.click(refreshBtn);
+    });
+
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it('subscribes to onSnapshotsUpdated on mount', async () => {
+    await act(async () => {
+      render(<DispatchDashboard />);
+    });
+
+    expect(mockOnSnapshotsUpdated).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('dismisses on X button click', async () => {
+    let result: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<DispatchDashboard />);
+    });
+
+    const dismissBtn = result!.getByLabelText('Dismiss');
+    await act(async () => {
+      fireEvent.click(dismissBtn);
+    });
+
+    // After dismiss, the Dispatch header should no longer be queryable
+    // (AnimatePresence may keep DOM briefly, so use waitFor)
+    await waitFor(() => {
+      expect(result!.queryByText('Dispatch')).toBeNull();
+    });
+  });
+});

--- a/test/services/DashboardPoller.test.ts
+++ b/test/services/DashboardPoller.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { BrowserWindow } from 'electron';
+
+const mockSend = vi.fn();
+vi.spyOn(BrowserWindow, 'getAllWindows').mockReturnValue([
+  { isDestroyed: () => false, webContents: { send: mockSend } } as any,
+]);
+
+vi.mock('../../electron/config/HealthEndpointConfig', () => ({
+  getAllEndpoints: vi.fn(() => ({
+    'finbiz': { type: 'http', url: 'http://localhost:9101/health' },
+    'qualiaai': { type: 'http', url: 'http://localhost:9102/health' },
+  })),
+}));
+
+vi.mock('../../electron/services/HealthSnapshotFetcher', () => ({
+  healthSnapshotFetcher: { fetchForProject: vi.fn() },
+}));
+
+vi.mock('../../electron/services/HealthSnapshotSerializer', () => ({
+  serializeSnapshot: vi.fn((s: any) => `# ${s.projectId} Health — ${s.fetchedAt}\n\n**Status:** ${s.status}`),
+  serializeError: vi.fn((id: string, err: string) => `# ${id} Health — error\n\n**Status:** unavailable\n\n${err}`),
+}));
+
+import { DashboardPoller } from '../../electron/services/DashboardPoller';
+import { healthSnapshotFetcher } from '../../electron/services/HealthSnapshotFetcher';
+
+const mockFetchForProject = healthSnapshotFetcher.fetchForProject as ReturnType<typeof vi.fn>;
+
+describe('DashboardPoller', () => {
+  let poller: DashboardPoller;
+  const mockWriteChunk = vi.fn();
+  const mockGetLatestChunk = vi.fn();
+  const mockWriter = {
+    writeChunk: mockWriteChunk,
+    getLatestChunk: mockGetLatestChunk,
+  } as any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSend.mockClear();
+    mockFetchForProject.mockReset();
+    mockWriteChunk.mockReset();
+    mockGetLatestChunk.mockReset();
+    poller = new DashboardPoller(mockWriter, 60_000);
+  });
+
+  afterEach(() => {
+    poller.stop();
+    vi.useRealTimers();
+  });
+
+  it('_runCycle fetches all configured projects and broadcasts', async () => {
+    const snap1 = { projectId: 'finbiz', status: 'healthy', alerts: [], blockers: [], fetchedAt: '2026-05-01T10:00:00Z' };
+    const snap2 = { projectId: 'qualiaai', status: 'degraded', alerts: ['high latency'], blockers: [], fetchedAt: '2026-05-01T10:00:00Z' };
+    mockFetchForProject.mockResolvedValueOnce(snap1).mockResolvedValueOnce(snap2);
+    mockGetLatestChunk
+      .mockReturnValueOnce({ projectId: 'finbiz', content: '# Finbiz', fetchedAt: snap1.fetchedAt, stale: false })
+      .mockReturnValueOnce({ projectId: 'qualiaai', content: '# Qualiaai', fetchedAt: snap2.fetchedAt, stale: false });
+
+    await poller._runCycle();
+
+    expect(mockFetchForProject).toHaveBeenCalledTimes(2);
+    expect(mockFetchForProject).toHaveBeenCalledWith('finbiz');
+    expect(mockFetchForProject).toHaveBeenCalledWith('qualiaai');
+    expect(mockWriteChunk).toHaveBeenCalledTimes(2);
+    expect(mockSend).toHaveBeenCalledWith('dashboard:snapshots-updated', expect.any(Array));
+    expect(mockSend.mock.calls[0][1]).toHaveLength(2);
+  });
+
+  it('_runCycle handles partial fetch failures gracefully', async () => {
+    mockFetchForProject
+      .mockRejectedValueOnce(new Error('connection refused'))
+      .mockResolvedValueOnce({ projectId: 'qualiaai', status: 'healthy', alerts: [], blockers: [], fetchedAt: '2026-05-01T10:00:00Z' });
+    mockGetLatestChunk
+      .mockReturnValueOnce({ projectId: 'finbiz', content: '# error', fetchedAt: '2026-05-01T10:00:00Z', stale: false })
+      .mockReturnValueOnce({ projectId: 'qualiaai', content: '# ok', fetchedAt: '2026-05-01T10:00:00Z', stale: false });
+
+    await poller._runCycle();
+
+    expect(mockSend).toHaveBeenCalledWith('dashboard:snapshots-updated', expect.any(Array));
+    expect(mockSend.mock.calls[0][1]).toHaveLength(2);
+  });
+
+  it('start() triggers immediate _runCycle', async () => {
+    const spy = vi.spyOn(poller, '_runCycle').mockResolvedValue();
+    poller.start();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('setInterval() restarts with new interval', () => {
+    const spy = vi.spyOn(poller, '_runCycle').mockResolvedValue();
+    poller.start(60_000);
+
+    expect(poller.getIntervalMs()).toBe(60_000);
+    poller.setInterval(30_000);
+    expect(poller.getIntervalMs()).toBe(30_000);
+
+    // Should have restarted (called _runCycle again from start)
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('stop() clears the timer', () => {
+    vi.spyOn(poller, '_runCycle').mockResolvedValue();
+    poller.start();
+    poller.stop();
+
+    // Advancing time should not trigger another cycle
+    const callCount = (poller._runCycle as any).mock.calls.length;
+    vi.advanceTimersByTime(120_000);
+    expect((poller._runCycle as any).mock.calls.length).toBe(callCount);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a live morning-briefing dashboard panel to Cluely that aggregates health/status across all active projects (Finbiz, QualiaAI, Ev0, Signal, Succession, scraping-doctor) in a single view with auto-refresh every 5 minutes.

The health-snapshot infrastructure (`HealthSnapshotFetcher`, `HealthChunkWriter`, `HealthEndpointConfig`) was already in place but nothing polled projects on a schedule or rendered the data in the UI. This PR wires the missing pieces end-to-end.

## Changes

### New files
- `electron/services/DashboardPoller.ts` — polling service mirroring `BackgroundAgent` timer lifecycle; fetches all configured project endpoints in parallel (`Promise.allSettled`), writes results via `HealthChunkWriter`, broadcasts `dashboard:snapshots-updated` to all renderer windows
- `electron/ipc/dashboardHandlers.ts` — IPC handlers for `dashboard:get-snapshots` and `dashboard:refresh` channels, registered via `SafeHandleRegistrar` pattern
- `src/components/DispatchDashboard.tsx` — React panel (framer-motion + Tailwind violet palette) showing a status card per project: health status badge (healthy/degraded/unavailable), alert count, stale indicator, relative fetch time, and a manual Refresh button
- `test/services/DashboardPoller.test.ts` — 5 unit tests covering polling, partial fetch failures, interval control, and broadcast
- `test/components/DispatchDashboard.test.tsx` — 7 component tests covering rendering, status badges, stale indicator, refresh button, and IPC subscription lifecycle

### Updated files
- `electron/config/projectHealthEndpoints.json` — populated with placeholder HTTP entries for all 6 projects (was empty `{}`)
- `electron/ipcHandlers.ts` — wires `registerDashboardHandlers()` into `initializeIpcHandlers()`
- `electron/main.ts` — adds `DashboardPoller` and `HealthChunkWriter` fields to `AppState`, initializes and starts the poller in `initializeApp()`, stops it in `before-quit`
- `electron/preload.ts` — adds `dashboard` section to `ElectronAPI` interface and `contextBridge` implementation (`getSnapshots`, `refresh`, `onSnapshotsUpdated`)

### Notable implementation decisions
- `Promise.allSettled` in `_runCycle`: one failing endpoint does not block the rest — failed projects show as `unavailable`
- Status and alert count are parsed from stored markdown content via lightweight regex (no new storage schema needed)
- Polling interval defaults to 5 min (vs BackgroundAgent's 30 min) — health checks are lightweight HTTP calls
- Separate `DashboardPoller` class (not folded into `BackgroundAgent`) to keep concerns isolated per existing pattern

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | ✅ No errors |
| New tests (12 tests across 2 files) | ✅ All passed |
| Full suite (`npx vitest run`) | ✅ 407 tests, 0 failures (75 files) |
| `npm run build` | ✅ Compiled in 2.84s |

Fixes #19