### PR TITLE
feat: add proactive advice engine with overlay nudge toasts

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -102,6 +102,7 @@ import { CommitmentStalenessChecker, CommitmentQuerySource } from "./services/Co
 import { BackgroundAgent } from "./services/BackgroundAgent"
 import { DashboardPoller } from './services/DashboardPoller'
 import { TokenUsageTracker } from "./services/TokenUsageTracker"
+import { ProactiveAdviceEngine } from "./services/ProactiveAdviceEngine"
 import { getAgentConfig, setAgentIntervalMs } from "./config/agentConfig"
 
 export class AppState {
@@ -130,6 +131,7 @@ export class AppState {
   private agentStateManager: AgentStateManager = new AgentStateManager()
   private backgroundAgent: BackgroundAgent | null = null
   private dashboardPoller: DashboardPoller | null = null
+  private proactiveAdviceEngine: ProactiveAdviceEngine | null = null
   private _healthChunkWriter: import('./services/HealthChunkWriter').HealthChunkWriter | null = null
   private tokenUsageTracker: TokenUsageTracker = new TokenUsageTracker()
   private activeMeetingId: string = ''
@@ -196,6 +198,15 @@ export class AppState {
 
 
 
+
+    // Initialize ProactiveAdviceEngine (must be after ProcessingHelper for LLMHelper access)
+    this.proactiveAdviceEngine = new ProactiveAdviceEngine(
+      this.lunrIndexer,
+      this.processingHelper.getLLMHelper(),
+    );
+    IpcEventBus.onTyped('proactive:nudge', (payload) => {
+      this.broadcast('proactive:nudge', payload);
+    });
 
     // Initialize IntelligenceManager with LLMHelper
     this.intelligenceManager = new IntelligenceManager(this.processingHelper.getLLMHelper())

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -210,6 +210,11 @@ interface ElectronAPI {
     onSnapshotsUpdated: (cb: (snapshots: Array<{ projectId: string; content: string; fetchedAt: string; stale: boolean }>) => void) => () => void;
   };
 
+  // Proactive Advice
+  proactiveAdvice: {
+    onNudge: (cb: (data: { message: string; meeting_id: string; timestamp: number }) => void) => () => void;
+  };
+
   // Goal Management
   goalCreate: (opts: { title: string; description?: string; parent_id?: string }) => Promise<{ id: string; title: string } | { error: string }>;
   goalList: () => Promise<Array<{ id: string; title: string; description: string; parent_id: string | null; created_at: number; completed_at: number | null }>>;
@@ -859,6 +864,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
       const subscription = (_: any, data: any) => cb(data);
       ipcRenderer.on('dashboard:snapshots-updated', subscription);
       return () => ipcRenderer.removeListener('dashboard:snapshots-updated', subscription);
+    },
+  },
+
+  // Proactive Advice API
+  proactiveAdvice: {
+    onNudge: (cb: (data: { message: string; meeting_id: string; timestamp: number }) => void) => {
+      const subscription = (_: any, data: any) => cb(data);
+      ipcRenderer.on('proactive:nudge', subscription);
+      return () => ipcRenderer.removeListener('proactive:nudge', subscription);
     },
   },
 

--- a/electron/services/IpcEventBus.ts
+++ b/electron/services/IpcEventBus.ts
@@ -26,6 +26,12 @@ export interface LiveNoteSnapshot {
   turn_count: number;
 }
 
+export interface ProactiveNudgePayload {
+  message: string;
+  meeting_id: string;
+  timestamp: number; // ms since epoch
+}
+
 type BusEvents = {
   "decision:captured": DecisionCapturedEvent;
   "notes:updated": LiveNoteSnapshot;
@@ -33,6 +39,7 @@ type BusEvents = {
   "meeting:ended": { meeting_id: string };
   "token:anomaly": TokenAnomalyEvent;
   "kb:updated": { summary: string; timestamp: number };
+  "proactive:nudge": ProactiveNudgePayload;
 };
 
 class IpcEventBusClass extends EventEmitter {

--- a/electron/services/ProactiveAdviceEngine.ts
+++ b/electron/services/ProactiveAdviceEngine.ts
@@ -1,0 +1,76 @@
+import { IpcEventBus, DecisionCapturedEvent } from './IpcEventBus';
+import { LunrIndexer, SpeakerTurn } from './LunrIndexer';
+import { LLMHelper } from '../LLMHelper';
+
+const THROTTLE_MS = 120_000; // 2 minutes
+
+const NUDGE_PROMPT = (recentTurns: SpeakerTurn[], event: DecisionCapturedEvent): string =>
+  `You are a real-time meeting advisor watching a live conversation.
+Recent transcript:
+${recentTurns.slice(-5).map(t => `${t.speaker}: ${t.text}`).join('\n')}
+
+A ${event.type} pattern was just detected: "${event.text_excerpt}" (speaker: ${event.speaker})
+
+Generate ONE brief nudge (max 15 words) to help the participant address what may be missed.
+
+Respond in JSON only, no markdown:
+{"message":"<nudge text>"}`;
+
+export class ProactiveAdviceEngine {
+  private lastNudgeAt: number | null = null;
+  private currentMeetingId = '';
+  private readonly decisionHandler: (e: DecisionCapturedEvent) => void;
+  private readonly meetingStartedHandler: (e: { meeting_id: string }) => void;
+  private readonly meetingEndedHandler: () => void;
+
+  constructor(
+    private readonly lunrIndexer: LunrIndexer,
+    private readonly llmHelper: LLMHelper,
+  ) {
+    this.decisionHandler = (e) => void this._handleDecision(e);
+    this.meetingStartedHandler = ({ meeting_id }) => {
+      this.currentMeetingId = meeting_id;
+      this.lastNudgeAt = null;
+    };
+    this.meetingEndedHandler = () => {
+      this.currentMeetingId = '';
+      this.lastNudgeAt = null;
+    };
+    IpcEventBus.onTyped('decision:captured', this.decisionHandler);
+    IpcEventBus.onTyped('meeting:started', this.meetingStartedHandler);
+    IpcEventBus.onTyped('meeting:ended', this.meetingEndedHandler);
+  }
+
+  private async _handleDecision(event: DecisionCapturedEvent): Promise<void> {
+    const now = Date.now();
+    if (this.lastNudgeAt !== null && now - this.lastNudgeAt < THROTTLE_MS) return;
+
+    const message = await this._generateNudge(event);
+    if (!message) return;
+
+    this.lastNudgeAt = now;
+    IpcEventBus.emitTyped('proactive:nudge', {
+      message,
+      meeting_id: this.currentMeetingId,
+      timestamp: now,
+    });
+  }
+
+  private async _generateNudge(event: DecisionCapturedEvent): Promise<string | null> {
+    try {
+      const recentTurns = this.lunrIndexer.getWindow(300);
+      const raw = await this.llmHelper.chat(NUDGE_PROMPT(recentTurns, event));
+      const parsed = JSON.parse(raw) as { message: string };
+      return typeof parsed.message === 'string' ? parsed.message : null;
+    } catch (err) {
+      console.warn('[ProactiveAdviceEngine] Failed to generate nudge:', err);
+      return null;
+    }
+  }
+
+  dispose(): void {
+    IpcEventBus.offTyped('decision:captured', this.decisionHandler);
+    IpcEventBus.offTyped('meeting:started', this.meetingStartedHandler);
+    IpcEventBus.offTyped('meeting:ended', this.meetingEndedHandler);
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { SupportToaster } from "./components/SupportToaster"
 import { analytics } from "./lib/analytics/analytics.service"
 import { LanguageProvider } from "./i18n"
 import { TranscriptSearchOverlay } from "./components/TranscriptSearchOverlay"
+import { ProactiveNudgeToast } from "./components/ProactiveNudgeToast"
 
 const queryClient = new QueryClient()
 
@@ -154,6 +155,7 @@ const App: React.FC = () => {
                 onEndMeeting={handleEndMeeting}
               />
               <TranscriptSearchOverlay />
+              <ProactiveNudgeToast />
               <ToastViewport />
             </ToastProvider>
           </QueryClientProvider>

--- a/src/components/ProactiveNudgeToast.tsx
+++ b/src/components/ProactiveNudgeToast.tsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+interface NudgePayload {
+  message: string;
+  meeting_id: string;
+  timestamp: number;
+}
+
+export function ProactiveNudgeToast() {
+  const [nudge, setNudge] = useState<NudgePayload | null>(null);
+
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api?.proactiveAdvice) return;
+    const cleanup = api.proactiveAdvice.onNudge((data: NudgePayload) => {
+      setNudge(data);
+    });
+    return cleanup;
+  }, []);
+
+  // Auto-dismiss after 10 seconds
+  useEffect(() => {
+    if (!nudge) return;
+    const t = setTimeout(() => setNudge(null), 10_000);
+    return () => clearTimeout(t);
+  }, [nudge]);
+
+  return (
+    <AnimatePresence>
+      {nudge && (
+        <motion.div
+          key={nudge.timestamp}
+          initial={{ opacity: 0, scale: 0.98, y: 4 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.98, y: 4 }}
+          transition={{ duration: 0.2, ease: 'easeOut' }}
+          style={{ zIndex: 9999 }}
+          className="fixed top-4 right-4 max-w-xs w-full"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex items-start gap-3 rounded-lg bg-gray-900/90 backdrop-blur-sm border border-gray-700 p-3 shadow-lg">
+            <span className="mt-0.5 text-indigo-400 shrink-0">&#x1f4a1;</span>
+            <p className="text-sm text-gray-100 flex-1">{nudge.message}</p>
+            <button
+              aria-label="Dismiss"
+              onClick={() => setNudge(null)}
+              className="text-gray-500 hover:text-gray-300 transition-colors shrink-0"
+            >
+              &#x2715;
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/test/components/ProactiveNudgeToast.test.tsx
+++ b/test/components/ProactiveNudgeToast.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, waitFor, fireEvent, act, cleanup } from '@testing-library/react';
+import { ProactiveNudgeToast } from '../../src/components/ProactiveNudgeToast';
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+  motion: {
+    div: React.forwardRef(({ children, ...props }: any, ref: any) => <div ref={ref} {...props}>{children}</div>),
+  },
+}));
+
+function setupElectronAPI(onNudge = vi.fn().mockReturnValue(() => {})) {
+  (window as any).electronAPI = { proactiveAdvice: { onNudge } };
+  return onNudge;
+}
+
+describe('ProactiveNudgeToast', () => {
+  afterEach(() => { cleanup(); delete (window as any).electronAPI; });
+
+  it('renders nothing when electronAPI is missing', () => {
+    const { container } = render(<ProactiveNudgeToast />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nudge message when received', () => {
+    let nudgeCb: ((d: any) => void) | null = null;
+    setupElectronAPI(vi.fn().mockImplementation((cb: any) => { nudgeCb = cb; return () => {}; }));
+    const { getByText } = render(<ProactiveNudgeToast />);
+    act(() => nudgeCb!({ message: 'Address the pricing concern', meeting_id: 'm1', timestamp: Date.now() }));
+    expect(getByText('Address the pricing concern')).toBeTruthy();
+  });
+
+  it('dismisses on X click', () => {
+    let nudgeCb: ((d: any) => void) | null = null;
+    setupElectronAPI(vi.fn().mockImplementation((cb: any) => { nudgeCb = cb; return () => {}; }));
+    const { getByLabelText, container } = render(<ProactiveNudgeToast />);
+    act(() => nudgeCb!({ message: 'Test nudge', meeting_id: 'm1', timestamp: Date.now() }));
+    fireEvent.click(getByLabelText('Dismiss'));
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('auto-dismisses after 10 seconds', () => {
+    vi.useFakeTimers();
+    let nudgeCb: ((d: any) => void) | null = null;
+    setupElectronAPI(vi.fn().mockImplementation((cb: any) => { nudgeCb = cb; return () => {}; }));
+    const { container } = render(<ProactiveNudgeToast />);
+    act(() => nudgeCb!({ message: 'Test nudge', meeting_id: 'm1', timestamp: Date.now() }));
+    expect(container.querySelector('p')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(container.querySelector('p')).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/test/services/ProactiveAdviceEngine.test.ts
+++ b/test/services/ProactiveAdviceEngine.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ProactiveAdviceEngine } from '../../electron/services/ProactiveAdviceEngine';
+import { LunrIndexer } from '../../electron/services/LunrIndexer';
+import { IpcEventBus, DecisionCapturedEvent, ProactiveNudgePayload } from '../../electron/services/IpcEventBus';
+import { LLMHelper } from '../../electron/LLMHelper';
+
+const mockLLM = {
+  chat: vi.fn().mockResolvedValue('{"message":"You haven\'t addressed their concern"}'),
+} as unknown as LLMHelper;
+
+const makeEvent = (overrides: Partial<DecisionCapturedEvent> = {}): DecisionCapturedEvent => ({
+  type: 'commitment', speaker: 'Alice', timestamp: Date.now(),
+  text_excerpt: "I'll handle it", confidence: 0.7,
+  meeting_id: 'm1', turn_id: 't1', ...overrides,
+});
+
+describe('ProactiveAdviceEngine', () => {
+  let indexer: LunrIndexer;
+  let engine: ProactiveAdviceEngine;
+  let captured: ProactiveNudgePayload[];
+  let nudgeHandler: (p: ProactiveNudgePayload) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    indexer = new LunrIndexer();
+    captured = [];
+    nudgeHandler = (p) => captured.push(p);
+    IpcEventBus.onTyped('proactive:nudge', nudgeHandler);
+    engine = new ProactiveAdviceEngine(indexer, mockLLM);
+    IpcEventBus.emitTyped('meeting:started', { meeting_id: 'm1' });
+  });
+
+  afterEach(() => {
+    engine.dispose();
+    IpcEventBus.offTyped('proactive:nudge', nudgeHandler);
+  });
+
+  it('emits proactive:nudge on decision:captured when no throttle active', async () => {
+    IpcEventBus.emitTyped('decision:captured', makeEvent());
+    await vi.waitFor(() => expect(captured).toHaveLength(1));
+    expect(captured[0].message).toBe("You haven't addressed their concern");
+    expect(captured[0].meeting_id).toBe('m1');
+  });
+
+  it('throttles: second event within 2 min does not emit nudge', async () => {
+    IpcEventBus.emitTyped('decision:captured', makeEvent({ turn_id: 't1' }));
+    await vi.waitFor(() => expect(captured).toHaveLength(1));
+    IpcEventBus.emitTyped('decision:captured', makeEvent({ turn_id: 't2' }));
+    await new Promise(r => setTimeout(r, 50));
+    expect(captured).toHaveLength(1); // still 1
+  });
+
+  it('resets throttle on meeting:started', async () => {
+    IpcEventBus.emitTyped('decision:captured', makeEvent({ turn_id: 't1' }));
+    await vi.waitFor(() => expect(captured).toHaveLength(1));
+    IpcEventBus.emitTyped('meeting:started', { meeting_id: 'm2' });
+    IpcEventBus.emitTyped('decision:captured', makeEvent({ turn_id: 't2', meeting_id: 'm2' }));
+    await vi.waitFor(() => expect(captured).toHaveLength(2));
+  });
+
+  it('does not emit when LLM returns null/invalid JSON', async () => {
+    (mockLLM.chat as any).mockResolvedValueOnce('not json');
+    IpcEventBus.emitTyped('decision:captured', makeEvent());
+    await new Promise(r => setTimeout(r, 100));
+    expect(captured).toHaveLength(0);
+  });
+
+  it('dispose() stops all listener subscriptions', async () => {
+    engine.dispose();
+    IpcEventBus.emitTyped('decision:captured', makeEvent());
+    await new Promise(r => setTimeout(r, 50));
+    expect(mockLLM.chat).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements a real-time coaching layer (Proactive Advice Engine) that watches live transcripts and surfaces contextual nudges to the meeting participant via a dismissible toast in the overlay window.

- Subscribes to `decision:captured` IpcEventBus events from `SlidingWindowAnalyzer`
- Throttles to max **1 nudge per 2 minutes** to avoid noise
- Calls LLM with recent transcript context (last 5 turns) to generate a concise nudge (≤15 words)
- Emits `proactive:nudge` over the established IpcEventBus → AppState bridge pattern
- Renders an animated, dismissible toast (framer-motion, auto-dismisses after 10s) at top-right of overlay

## Changes

| File | Action | Description |
|------|--------|-------------|
| `electron/services/IpcEventBus.ts` | Updated | Added `ProactiveNudgePayload` interface and `"proactive:nudge"` event to `BusEvents` |
| `electron/services/ProactiveAdviceEngine.ts` | Created | New service: throttled LLM nudge generation on `decision:captured` |
| `electron/main.ts` | Updated | Declare + initialize `ProactiveAdviceEngine`; bridge `proactive:nudge` event to renderer |
| `electron/preload.ts` | Updated | Added `proactiveAdvice.onNudge` to `ElectronAPI` interface + `contextBridge` implementation |
| `src/components/ProactiveNudgeToast.tsx` | Created | Animated dismissible toast component for the overlay window |
| `src/App.tsx` | Updated | Render `<ProactiveNudgeToast />` inside overlay window block |
| `test/services/ProactiveAdviceEngine.test.ts` | Created | Unit tests: nudge emission, throttle, meeting reset, LLM failure, dispose |
| `test/components/ProactiveNudgeToast.test.tsx` | Created | Component tests: render on nudge, dismiss, auto-dismiss, missing API guard |

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit -p electron/tsconfig.json` | ✅ Pass |
| `npx tsc --noEmit` | ✅ Pass |
| New tests (9) | ✅ All pass |
| Full suite (`npx vitest run`) | ✅ 426/426 passed, 0 regressions |
| `npm run build` | ✅ Compiled in 2.88s |

## Design Notes

- **Bridge pattern**: Uses `IpcEventBus.emitTyped` → `AppState.broadcast` (same as `token:anomaly`) to keep the service free of Electron globals and fully testable
- **Throttle reset**: `lastNudgeAt` resets on `meeting:started` so the first detection in a new meeting always produces a nudge
- **Toast position**: Fixed `top-4 right-4` to avoid conflict with Radix UI `<ToastViewport>` at `bottom-0 right-0`
- **Out of scope**: Nudge history persistence, settings toggle, custom throttle config, multi-nudge queue

Fixes #2