### PR TITLE
feat(cost-tracking): per-meeting/per-model spend visibility with budget enforcement

### DIFF
--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -20,6 +20,9 @@ import { promisify } from 'util';
 import axios from 'axios';
 import { createProviderRateLimiters, RateLimiter } from './services/RateLimiter';
 import type { TokenUsageTracker } from './services/TokenUsageTracker';
+import { estimateCost } from './services/CostPricer';
+import type { MeetingCostTracker } from './services/MeetingCostTracker';
+import { IpcEventBus } from './services/IpcEventBus';
 const execAsync = promisify(exec);
 
 interface OllamaResponse {
@@ -57,6 +60,9 @@ export class LLMHelper {
   private activeCurlProvider: CurlProvider | null = null;
   private groqFastTextMode: boolean = false;
   private tokenTracker: TokenUsageTracker | null = null;
+  private costRecorder: MeetingCostTracker | null = null;
+  private activeMeetingId: string = '';
+  private dailyBudgetCents: number | null = null;
 
   // Rate limiters per provider to prevent 429 errors on free tiers
   private rateLimiters: ReturnType<typeof createProviderRateLimiters>;
@@ -110,6 +116,23 @@ export class LLMHelper {
 
   setTokenTracker(tracker: TokenUsageTracker): void {
     this.tokenTracker = tracker;
+  }
+
+  setCostRecorder(recorder: MeetingCostTracker): void {
+    this.costRecorder = recorder;
+  }
+
+  setActiveMeetingId(id: string): void {
+    this.activeMeetingId = id;
+  }
+
+  setDailyBudgetCents(cents: number | null): void {
+    this.dailyBudgetCents = cents;
+  }
+
+  private isDailyBudgetExceeded(): boolean {
+    if (!this.costRecorder || !this.dailyBudgetCents) return false;
+    return this.costRecorder.isOverDailyBudget(this.dailyBudgetCents);
   }
 
   public setApiKey(apiKey: string) {
@@ -379,8 +402,12 @@ export class LLMHelper {
         temperature: 0.3,      // Lower = faster, more focused
       }
     })
-    const tokens = response.usageMetadata?.totalTokenCount;
-    if (tokens) this.tokenTracker?.record(tokens);
+    const inputTokens = response.usageMetadata?.promptTokenCount ?? 0;
+    const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
+    const totalTokens = inputTokens + outputTokens;
+    if (totalTokens) this.tokenTracker?.record(totalTokens);
+    const costCents = estimateCost('gemini', GEMINI_FLASH_MODEL, inputTokens, outputTokens);
+    this.costRecorder?.record({ meetingId: this.activeMeetingId || null, provider: 'gemini', model: GEMINI_FLASH_MODEL, inputTokens, outputTokens, costCents });
     return response.text || ""
   }
 
@@ -401,8 +428,12 @@ export class LLMHelper {
         temperature: 0.3,      // Lower = faster, more focused
       }
     })
-    const tokens = response.usageMetadata?.totalTokenCount;
-    if (tokens) this.tokenTracker?.record(tokens);
+    const inputTokens = response.usageMetadata?.promptTokenCount ?? 0;
+    const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
+    const totalTokens = inputTokens + outputTokens;
+    if (totalTokens) this.tokenTracker?.record(totalTokens);
+    const costCents = estimateCost('gemini', GEMINI_FLASH_MODEL, inputTokens, outputTokens);
+    this.costRecorder?.record({ meetingId: this.activeMeetingId || null, provider: 'gemini', model: GEMINI_FLASH_MODEL, inputTokens, outputTokens, costCents });
     return response.text || ""
   }
 
@@ -745,6 +776,16 @@ ANSWER DIRECTLY:`;
   }
 
   public async chatWithGemini(message: string, imagePath?: string, context?: string, skipSystemPrompt: boolean = false, alternateGroqMessage?: string): Promise<string> {
+    if (this.isDailyBudgetExceeded()) {
+      IpcEventBus.emitTyped("cost:budget-exceeded", {
+        meeting_id: this.activeMeetingId || null,
+        daily_cents: this.costRecorder!.getDailySpend().totalCents,
+        budget_cents: this.dailyBudgetCents!,
+        timestamp: Date.now(),
+      });
+      throw new Error('Daily LLM budget exceeded');
+    }
+
     try {
       console.log(`[LLMHelper] chatWithGemini called with message:`, message.substring(0, 50))
 
@@ -960,8 +1001,11 @@ ANSWER DIRECTLY:`;
       stream: false
     });
 
-    const tokens = response.usage?.total_tokens;
-    if (tokens) this.tokenTracker?.record(tokens);
+    const inputTokens = response.usage?.prompt_tokens ?? 0;
+    const outputTokens = response.usage?.completion_tokens ?? 0;
+    if (inputTokens + outputTokens) this.tokenTracker?.record(inputTokens + outputTokens);
+    const costCents = estimateCost('groq', GROQ_MODEL, inputTokens, outputTokens);
+    this.costRecorder?.record({ meetingId: this.activeMeetingId || null, provider: 'groq', model: GROQ_MODEL, inputTokens, outputTokens, costCents });
 
     return response.choices[0]?.message?.content || "";
   }
@@ -1000,8 +1044,11 @@ ANSWER DIRECTLY:`;
       ? await client!.chat.completions.create({ model: modelId, messages, temperature: 0.4, max_tokens: 8192 } as any)
       : await this.openaiChatCompletionsCreateWithTokenFallback({ model: modelId, messages, temperature: 0.4, maxTokens: 8192 });
 
-    const tokens = (response as any).usage?.total_tokens;
-    if (tokens) this.tokenTracker?.record(tokens);
+    const inputTokens = (response as any).usage?.prompt_tokens ?? 0;
+    const outputTokens = (response as any).usage?.completion_tokens ?? 0;
+    if (inputTokens + outputTokens) this.tokenTracker?.record(inputTokens + outputTokens);
+    const costCents = estimateCost(isOpenRouter ? 'openrouter' : 'openai', modelId, inputTokens, outputTokens);
+    this.costRecorder?.record({ meetingId: this.activeMeetingId || null, provider: isOpenRouter ? 'openrouter' : 'openai', model: modelId, inputTokens, outputTokens, costCents });
 
     return (response as any).choices[0]?.message?.content || "";
   }
@@ -1083,6 +1130,12 @@ ANSWER DIRECTLY:`;
       ...(systemPrompt ? { system: systemPrompt } : {}),
       messages: [{ role: "user", content }],
     });
+
+    const inputTokens = (response as any).usage?.input_tokens ?? 0;
+    const outputTokens = (response as any).usage?.output_tokens ?? 0;
+    if (inputTokens + outputTokens) this.tokenTracker?.record(inputTokens + outputTokens);
+    const costCents = estimateCost('claude', CLAUDE_MODEL, inputTokens, outputTokens);
+    this.costRecorder?.record({ meetingId: this.activeMeetingId || null, provider: 'claude', model: CLAUDE_MODEL, inputTokens, outputTokens, costCents });
 
     const textBlock = response.content.find((block: any) => block.type === 'text') as any;
     return textBlock?.text || "";

--- a/electron/ipc/costHandlers.ts
+++ b/electron/ipc/costHandlers.ts
@@ -1,0 +1,51 @@
+import type { MeetingCostTracker } from '../services/MeetingCostTracker';
+import type { CredentialsManager } from '../services/CredentialsManager';
+
+type SafeHandleRegistrar = {
+  safeHandle(channel: string, listener: (event: any, ...args: any[]) => Promise<any> | any): void;
+};
+
+export function registerCostHandlers(
+  registrar: SafeHandleRegistrar,
+  costTracker: MeetingCostTracker | null,
+  credsMgr: CredentialsManager,
+): void {
+  registrar.safeHandle('cost:get-session-spend', async (_event: any, meetingId: string) => {
+    if (!costTracker) return { totalCents: 0, byModel: [] };
+    try {
+      return costTracker.getMeetingSpend(meetingId);
+    } catch (err: any) {
+      console.error('[costHandlers] get-session-spend failed:', err);
+      return { error: err.message };
+    }
+  });
+
+  registrar.safeHandle('cost:get-daily-spend', async (_event: any, date?: string) => {
+    if (!costTracker) return { totalCents: 0, byModel: [] };
+    try {
+      return costTracker.getDailySpend(date);
+    } catch (err: any) {
+      console.error('[costHandlers] get-daily-spend failed:', err);
+      return { error: err.message };
+    }
+  });
+
+  registrar.safeHandle('cost:set-daily-budget', async (_event: any, cents: number) => {
+    try {
+      credsMgr.setGlobalDailyBudgetCents(cents);
+      return { success: true };
+    } catch (err: any) {
+      console.error('[costHandlers] set-daily-budget failed:', err);
+      return { error: err.message };
+    }
+  });
+
+  registrar.safeHandle('cost:get-daily-budget', async () => {
+    try {
+      return credsMgr.getGlobalDailyBudgetCents();
+    } catch (err: any) {
+      console.error('[costHandlers] get-daily-budget failed:', err);
+      return { error: err.message };
+    }
+  });
+}

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -11,6 +11,8 @@ import { AudioDevices } from "./audio/AudioDevices";
 
 import { ENGLISH_VARIANTS } from "./config/languages"
 import { registerDashboardHandlers } from './ipc/dashboardHandlers';
+import { registerCostHandlers } from './ipc/costHandlers';
+import { CredentialsManager } from './services/CredentialsManager';
 
 export function initializeIpcHandlers(appState: AppState): void {
   const safeHandle = (channel: string, listener: (event: any, ...args: any[]) => Promise<any> | any) => {
@@ -1924,5 +1926,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     { safeHandle },
     appState.getHealthChunkWriter(),
     appState.getDashboardPoller(),
+  );
+
+  // Cost Tracking handlers
+  registerCostHandlers(
+    { safeHandle },
+    appState.getMeetingCostTracker(),
+    CredentialsManager.getInstance(),
   );
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -97,6 +97,8 @@ import { CorpusIndexer } from "./corpus/CorpusIndexer"
 import { loadCorpusConfig } from "./corpus/corpus.config"
 import { GoalAligner } from "./memory/GoalAligner"
 import { AgentStateManager } from "./services/AgentStateManager"
+import { MeetingCostTracker } from "./services/MeetingCostTracker"
+import { registerCostHandlers } from "./ipc/costHandlers"
 import { PermissionsAuditLog } from "./services/PermissionsAuditLog"
 import { CommitmentStalenessChecker, CommitmentQuerySource } from "./services/CommitmentStalenessChecker"
 import { BackgroundAgent } from "./services/BackgroundAgent"
@@ -132,6 +134,7 @@ export class AppState {
   private dashboardPoller: DashboardPoller | null = null
   private _healthChunkWriter: import('./services/HealthChunkWriter').HealthChunkWriter | null = null
   private tokenUsageTracker: TokenUsageTracker = new TokenUsageTracker()
+  private meetingCostTracker: MeetingCostTracker | null = null
   private activeMeetingId: string = ''
   private turnCounter: number = 0
 
@@ -229,8 +232,23 @@ export class AppState {
 
     this.processingHelper.getLLMHelper().setTokenTracker(this.tokenUsageTracker)
 
+    // Initialize MeetingCostTracker
+    const costDb = DatabaseManager.getInstance().getDb();
+    if (costDb) {
+      this.meetingCostTracker = new MeetingCostTracker(costDb);
+      const llm = this.processingHelper.getLLMHelper();
+      llm.setCostRecorder(this.meetingCostTracker);
+      const budgetCents = CredentialsManager.getInstance().getGlobalDailyBudgetCents();
+      if (budgetCents !== null) llm.setDailyBudgetCents(budgetCents);
+      console.log('[AppState] MeetingCostTracker initialized');
+    }
+
     IpcEventBus.onTyped("token:anomaly", (payload) => {
       this.broadcast("health:token-anomaly", payload)
+    })
+
+    IpcEventBus.onTyped("cost:budget-exceeded", (payload) => {
+      this.broadcast("cost:budget-exceeded", payload)
     })
 
     this.setupIntelligenceEvents()
@@ -950,6 +968,7 @@ export class AppState {
     this.slidingWindowAnalyzer.start(meetingId);
     this.tokenUsageTracker.start(meetingId);
     this.liveNotesExtractor.start(meetingId);
+    this.processingHelper.getLLMHelper().setActiveMeetingId(meetingId);
     IpcEventBus.emitTyped("meeting:started", { meeting_id: meetingId });
   }
 
@@ -970,6 +989,7 @@ export class AppState {
     this.tokenUsageTracker.stop();
     this.liveNotesExtractor.stop();
     this.lunrIndexer.clear();
+    this.processingHelper.getLLMHelper().setActiveMeetingId('');
     IpcEventBus.emitTyped("meeting:ended", { meeting_id: this.activeMeetingId });
 
     // 6. Reset Intelligence Context & Save
@@ -1207,6 +1227,10 @@ export class AppState {
 
   public getHealthChunkWriter(): import('./services/HealthChunkWriter').HealthChunkWriter | null {
     return this._healthChunkWriter;
+  }
+
+  public getMeetingCostTracker(): MeetingCostTracker | null {
+    return this.meetingCostTracker;
   }
 
   public getView(): "queue" | "solutions" {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -210,6 +210,15 @@ interface ElectronAPI {
     onSnapshotsUpdated: (cb: (snapshots: Array<{ projectId: string; content: string; fetchedAt: string; stale: boolean }>) => void) => () => void;
   };
 
+  // Cost Tracking API
+  cost: {
+    getSessionSpend: (meetingId: string) => Promise<{ totalCents: number; byModel: Array<{ provider: string; model: string; inputTokens: number; outputTokens: number; costCents: number }> }>;
+    getDailySpend: (date?: string) => Promise<{ totalCents: number; byModel: Array<{ provider: string; model: string; inputTokens: number; outputTokens: number; costCents: number }> }>;
+    setDailyBudget: (cents: number) => Promise<{ success: boolean }>;
+    getDailyBudget: () => Promise<number | null>;
+    onBudgetExceeded: (cb: (payload: { meeting_id: string | null; daily_cents: number; budget_cents: number }) => void) => () => void;
+  };
+
   // Goal Management
   goalCreate: (opts: { title: string; description?: string; parent_id?: string }) => Promise<{ id: string; title: string } | { error: string }>;
   goalList: () => Promise<Array<{ id: string; title: string; description: string; parent_id: string | null; created_at: number; completed_at: number | null }>>;
@@ -859,6 +868,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
       const subscription = (_: any, data: any) => cb(data);
       ipcRenderer.on('dashboard:snapshots-updated', subscription);
       return () => ipcRenderer.removeListener('dashboard:snapshots-updated', subscription);
+    },
+  },
+
+  // Cost Tracking API
+  cost: {
+    getSessionSpend: (meetingId: string) => ipcRenderer.invoke('cost:get-session-spend', meetingId),
+    getDailySpend: (date?: string) => ipcRenderer.invoke('cost:get-daily-spend', date),
+    setDailyBudget: (cents: number) => ipcRenderer.invoke('cost:set-daily-budget', cents),
+    getDailyBudget: () => ipcRenderer.invoke('cost:get-daily-budget'),
+    onBudgetExceeded: (cb: (payload: any) => void) => {
+      const subscription = (_: any, data: any) => cb(data);
+      ipcRenderer.on('cost:budget-exceeded', subscription);
+      return () => ipcRenderer.removeListener('cost:budget-exceeded', subscription);
     },
   },
 

--- a/electron/services/BackgroundAgent.ts
+++ b/electron/services/BackgroundAgent.ts
@@ -89,16 +89,18 @@ export class BackgroundAgent {
     }
 
     const drafts: WorkflowDraft[] = [];
+    let events: Awaited<ReturnType<typeof this.calendarSource.getUpcomingEvents>> = [];
+    const now = Date.now();
 
     // 1. Calendar scan — look for events starting within 5 minutes
     try {
       this.auditLog.append({ dataType: 'calendar', purpose: 'pre-meeting-scan' });
-      const events = await this.calendarSource.getUpcomingEvents(true);
-      const now = Date.now();
+      events = await this.calendarSource.getUpcomingEvents(true);
 
       for (const event of events) {
         const startMs = new Date(event.startTime).getTime();
         const diff = startMs - now;
+
         if (diff >= 0 && diff <= PRE_BRIEF_WINDOW_MS) {
           // Existing broadcast (keep for backward compat)
           this.broadcast('agent:pre-brief-ready', {

--- a/electron/services/CostPricer.ts
+++ b/electron/services/CostPricer.ts
@@ -1,0 +1,23 @@
+/**
+ * Static pricing table and cost estimation for LLM providers.
+ * Pure functions — no electron or IPC dependencies.
+ */
+
+// TODO: update pricing — these are approximate 2026 values
+export const PROVIDER_PRICING: Record<string, { inputCentsPerMToken: number; outputCentsPerMToken: number }> = {
+  'gemini:gemini-3-flash-preview': { inputCentsPerMToken: 7.5, outputCentsPerMToken: 30 },
+  'gemini:gemini-3-pro-preview': { inputCentsPerMToken: 125, outputCentsPerMToken: 500 },
+  'groq:llama-3.3-70b-versatile': { inputCentsPerMToken: 59, outputCentsPerMToken: 79 },
+  'openai:gpt-5.2-chat-latest': { inputCentsPerMToken: 250, outputCentsPerMToken: 1000 },
+  'claude:claude-sonnet-4-5': { inputCentsPerMToken: 300, outputCentsPerMToken: 1500 },
+};
+
+export function estimateCost(provider: string, model: string, inputTokens: number, outputTokens: number): number {
+  const key = `${provider}:${model}`;
+  const pricing = PROVIDER_PRICING[key];
+  if (!pricing) {
+    console.warn('[CostPricer] Unknown model for pricing:', provider, model);
+    return 0;
+  }
+  return (inputTokens * pricing.inputCentsPerMToken + outputTokens * pricing.outputCentsPerMToken) / 1_000_000;
+}

--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -64,6 +64,7 @@ export interface StoredCredentials {
     openrouterModel?: string;
     exportWebhooks?: ExportWebhook[];
     backgroundAgent?: BackgroundAgentConfig;
+    globalDailyBudgetCents?: number;
 }
 
 export class CredentialsManager {
@@ -301,6 +302,16 @@ export class CredentialsManager {
         this.credentials.backgroundAgent.dailyBudgetCents = cents;
         this.saveCredentials();
         console.log(`[CredentialsManager] BackgroundAgent dailyBudgetCents: ${cents}`);
+    }
+
+    public getGlobalDailyBudgetCents(): number | null {
+        return this.credentials.globalDailyBudgetCents ?? null;
+    }
+
+    public setGlobalDailyBudgetCents(cents: number): void {
+        this.credentials.globalDailyBudgetCents = cents;
+        this.saveCredentials();
+        console.log(`[CredentialsManager] globalDailyBudgetCents: ${cents}`);
     }
 
     public saveCustomProvider(provider: CustomProvider): void {

--- a/electron/services/IpcEventBus.ts
+++ b/electron/services/IpcEventBus.ts
@@ -33,6 +33,12 @@ type BusEvents = {
   "meeting:ended": { meeting_id: string };
   "token:anomaly": TokenAnomalyEvent;
   "kb:updated": { summary: string; timestamp: number };
+  "cost:budget-exceeded": {
+    meeting_id: string | null;
+    daily_cents: number;
+    budget_cents: number;
+    timestamp: number;
+  };
 };
 
 class IpcEventBusClass extends EventEmitter {

--- a/electron/services/MeetingCostTracker.ts
+++ b/electron/services/MeetingCostTracker.ts
@@ -1,0 +1,66 @@
+import type Database from 'better-sqlite3';
+
+export type SpendRow = {
+  provider: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+};
+
+export class MeetingCostTracker {
+  private insertStmt: Database.Statement;
+  private meetingQueryStmt: Database.Statement;
+  private dailyQueryStmt: Database.Statement;
+  private dailyTotalStmt: Database.Statement;
+
+  constructor(private db: Database.Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS llm_cost_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp INTEGER NOT NULL,
+        meeting_id TEXT,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_cents REAL NOT NULL DEFAULT 0
+      )
+    `);
+    this.insertStmt = db.prepare(
+      'INSERT INTO llm_cost_log (timestamp, meeting_id, provider, model, input_tokens, output_tokens, cost_cents) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    );
+    this.meetingQueryStmt = db.prepare(
+      'SELECT provider, model, SUM(input_tokens) as inputTokens, SUM(output_tokens) as outputTokens, SUM(cost_cents) as costCents FROM llm_cost_log WHERE meeting_id = ? GROUP BY provider, model',
+    );
+    this.dailyQueryStmt = db.prepare(
+      "SELECT provider, model, SUM(input_tokens) as inputTokens, SUM(output_tokens) as outputTokens, SUM(cost_cents) as costCents FROM llm_cost_log WHERE date(timestamp/1000, 'unixepoch') = ? GROUP BY provider, model",
+    );
+    this.dailyTotalStmt = db.prepare(
+      "SELECT COALESCE(SUM(cost_cents), 0) as total FROM llm_cost_log WHERE date(timestamp/1000, 'unixepoch') = ?",
+    );
+  }
+
+  record(entry: { meetingId: string | null; provider: string; model: string; inputTokens: number; outputTokens: number; costCents: number }): void {
+    this.insertStmt.run(Date.now(), entry.meetingId, entry.provider, entry.model, entry.inputTokens, entry.outputTokens, entry.costCents);
+  }
+
+  getMeetingSpend(meetingId: string): { totalCents: number; byModel: SpendRow[] } {
+    const rows = this.meetingQueryStmt.all(meetingId) as SpendRow[];
+    const totalCents = rows.reduce((sum, r) => sum + r.costCents, 0);
+    return { totalCents, byModel: rows };
+  }
+
+  getDailySpend(date?: string): { totalCents: number; byModel: SpendRow[] } {
+    const day = date || new Date().toISOString().slice(0, 10);
+    const rows = this.dailyQueryStmt.all(day) as SpendRow[];
+    const totalCents = (this.dailyTotalStmt.get(day) as { total: number }).total;
+    return { totalCents, byModel: rows };
+  }
+
+  isOverDailyBudget(budgetCents: number): boolean {
+    const day = new Date().toISOString().slice(0, 10);
+    const total = (this.dailyTotalStmt.get(day) as { total: number }).total;
+    return total >= budgetCents;
+  }
+}

--- a/src/components/CostDashboard.tsx
+++ b/src/components/CostDashboard.tsx
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react';
+
+type SpendRow = { provider: string; model: string; inputTokens: number; outputTokens: number; costCents: number };
+type SpendData = { totalCents: number; byModel: SpendRow[] };
+
+export function CostDashboard({ meetingId }: { meetingId?: string }) {
+  const [sessionSpend, setSessionSpend] = useState<SpendData>({ totalCents: 0, byModel: [] });
+  const [dailySpend, setDailySpend] = useState<SpendData>({ totalCents: 0, byModel: [] });
+  const [dailyBudget, setDailyBudget] = useState<number | null>(null);
+  const [budgetExceeded, setBudgetExceeded] = useState(false);
+
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api?.cost) return;
+
+    if (meetingId) api.cost.getSessionSpend(meetingId).then(setSessionSpend).catch(console.warn);
+    api.cost.getDailySpend().then(setDailySpend).catch(console.warn);
+    api.cost.getDailyBudget().then(setDailyBudget).catch(console.warn);
+
+    const cleanup = api.cost.onBudgetExceeded(() => setBudgetExceeded(true));
+    return cleanup;
+  }, [meetingId]);
+
+  const fmtCents = (c: number) => `$${(c / 100).toFixed(4)}`;
+
+  return (
+    <div className="p-4 space-y-4">
+      {budgetExceeded && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded">
+          Daily AI budget exceeded — LLM calls are paused.
+        </div>
+      )}
+      {meetingId && (
+        <section>
+          <h3 className="font-semibold">Session spend</h3>
+          <p className="text-lg">{fmtCents(sessionSpend.totalCents)}</p>
+          <ModelTable rows={sessionSpend.byModel} fmtCents={fmtCents} />
+        </section>
+      )}
+      <section>
+        <h3 className="font-semibold">Today&apos;s spend</h3>
+        <p className="text-lg">{fmtCents(dailySpend.totalCents)}</p>
+        {dailyBudget !== null && (
+          <p className="text-sm text-gray-500">
+            Budget: {fmtCents(dailyBudget)} — {((dailySpend.totalCents / dailyBudget) * 100).toFixed(1)}% used
+          </p>
+        )}
+        <ModelTable rows={dailySpend.byModel} fmtCents={fmtCents} />
+      </section>
+    </div>
+  );
+}
+
+function ModelTable({ rows, fmtCents }: { rows: SpendRow[]; fmtCents: (c: number) => string }) {
+  if (!rows.length) return <p className="text-sm text-gray-400">No data</p>;
+  return (
+    <table className="w-full text-sm mt-2">
+      <thead><tr><th>Provider</th><th>Model</th><th>In</th><th>Out</th><th>Cost</th></tr></thead>
+      <tbody>
+        {rows.map((r, i) => (
+          <tr key={i}>
+            <td>{r.provider}</td><td>{r.model}</td>
+            <td>{r.inputTokens.toLocaleString()}</td>
+            <td>{r.outputTokens.toLocaleString()}</td>
+            <td>{fmtCents(r.costCents)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/test/services/CostPricer.test.ts
+++ b/test/services/CostPricer.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { estimateCost, PROVIDER_PRICING } from '../../electron/services/CostPricer';
+
+describe('CostPricer', () => {
+  it('calculates correct cost for known model (gemini flash)', () => {
+    // 1000 input tokens * 7.5 / 1M + 500 output tokens * 30 / 1M
+    const cost = estimateCost('gemini', 'gemini-3-flash-preview', 1000, 500);
+    expect(cost).toBeCloseTo((1000 * 7.5 + 500 * 30) / 1_000_000);
+  });
+
+  it('calculates correct cost for claude', () => {
+    const cost = estimateCost('claude', 'claude-sonnet-4-5', 1000, 1000);
+    expect(cost).toBeCloseTo((1000 * 300 + 1000 * 1500) / 1_000_000);
+  });
+
+  it('returns 0 for unknown model and does not throw', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cost = estimateCost('unknown', 'nonexistent-model', 1000, 500);
+    expect(cost).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith('[CostPricer] Unknown model for pricing:', 'unknown', 'nonexistent-model');
+    warnSpy.mockRestore();
+  });
+
+  it('returns 0 for zero tokens', () => {
+    const cost = estimateCost('gemini', 'gemini-3-flash-preview', 0, 0);
+    expect(cost).toBe(0);
+  });
+
+  it('has pricing entries for all expected providers', () => {
+    expect(PROVIDER_PRICING['gemini:gemini-3-flash-preview']).toBeDefined();
+    expect(PROVIDER_PRICING['gemini:gemini-3-pro-preview']).toBeDefined();
+    expect(PROVIDER_PRICING['groq:llama-3.3-70b-versatile']).toBeDefined();
+    expect(PROVIDER_PRICING['openai:gpt-5.2-chat-latest']).toBeDefined();
+    expect(PROVIDER_PRICING['claude:claude-sonnet-4-5']).toBeDefined();
+  });
+});

--- a/test/services/MeetingCostTracker.test.ts
+++ b/test/services/MeetingCostTracker.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { MeetingCostTracker } from '../../electron/services/MeetingCostTracker';
+
+describe('MeetingCostTracker', () => {
+  let tracker: MeetingCostTracker;
+
+  beforeEach(() => {
+    const db = new Database(':memory:');
+    tracker = new MeetingCostTracker(db);
+  });
+
+  it('starts with zero spend for unknown meeting', () => {
+    const spend = tracker.getMeetingSpend('mtg-x');
+    expect(spend.totalCents).toBe(0);
+    expect(spend.byModel).toHaveLength(0);
+  });
+
+  it('records and aggregates meeting spend', () => {
+    tracker.record({ meetingId: 'mtg-1', provider: 'groq', model: 'llama-3.3-70b-versatile', inputTokens: 100, outputTokens: 50, costCents: 1.2 });
+    tracker.record({ meetingId: 'mtg-1', provider: 'claude', model: 'claude-sonnet-4-5', inputTokens: 200, outputTokens: 100, costCents: 2.1 });
+    const spend = tracker.getMeetingSpend('mtg-1');
+    expect(spend.totalCents).toBeCloseTo(3.3);
+    expect(spend.byModel).toHaveLength(2);
+  });
+
+  it('isolates meetings from each other', () => {
+    tracker.record({ meetingId: 'mtg-1', provider: 'groq', model: 'llama-3.3-70b-versatile', inputTokens: 100, outputTokens: 50, costCents: 5.0 });
+    tracker.record({ meetingId: 'mtg-2', provider: 'groq', model: 'llama-3.3-70b-versatile', inputTokens: 100, outputTokens: 50, costCents: 3.0 });
+    expect(tracker.getMeetingSpend('mtg-1').totalCents).toBeCloseTo(5.0);
+    expect(tracker.getMeetingSpend('mtg-2').totalCents).toBeCloseTo(3.0);
+  });
+
+  it('records null meetingId (background agent calls)', () => {
+    tracker.record({ meetingId: null, provider: 'openai', model: 'gpt-5.2-chat-latest', inputTokens: 500, outputTokens: 200, costCents: 4.5 });
+    // Should not appear in meeting spend
+    expect(tracker.getMeetingSpend('').totalCents).toBe(0);
+    // Should appear in daily spend
+    const daily = tracker.getDailySpend();
+    expect(daily.totalCents).toBeCloseTo(4.5);
+  });
+
+  it('getDailySpend aggregates all calls for today', () => {
+    tracker.record({ meetingId: 'mtg-1', provider: 'groq', model: 'llama-3.3-70b-versatile', inputTokens: 100, outputTokens: 50, costCents: 1.0 });
+    tracker.record({ meetingId: 'mtg-2', provider: 'claude', model: 'claude-sonnet-4-5', inputTokens: 200, outputTokens: 100, costCents: 2.0 });
+    tracker.record({ meetingId: null, provider: 'openai', model: 'gpt-5.2-chat-latest', inputTokens: 300, outputTokens: 150, costCents: 3.0 });
+    const daily = tracker.getDailySpend();
+    expect(daily.totalCents).toBeCloseTo(6.0);
+    expect(daily.byModel).toHaveLength(3);
+  });
+
+  it('isOverDailyBudget returns true when exceeded', () => {
+    tracker.record({ meetingId: null, provider: 'openai', model: 'gpt-5.2-chat-latest', inputTokens: 1000, outputTokens: 500, costCents: 15.0 });
+    expect(tracker.isOverDailyBudget(10)).toBe(true);
+    expect(tracker.isOverDailyBudget(20)).toBe(false);
+  });
+
+  it('isOverDailyBudget returns true when exactly at budget', () => {
+    tracker.record({ meetingId: null, provider: 'openai', model: 'gpt-5.2-chat-latest', inputTokens: 1000, outputTokens: 500, costCents: 10.0 });
+    expect(tracker.isOverDailyBudget(10)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the Paperclip cost-tracking system into Cluely.fr, introducing full LLM spend visibility and optional budget enforcement. Previously, token counts died in memory — no cost was computed or stored, and users had zero observability into AI spending at any granularity.

- New `CostPricer` service with per-provider/model pricing table (Gemini Flash/Pro, Groq, OpenAI, Claude)
- New `MeetingCostTracker` persisting input/output tokens + cost to a `llm_cost_log` SQLite table with per-meeting and daily aggregation
- All four LLM providers (Gemini, Groq, OpenAI, Claude) now record input/output tokens separately — Claude token recording was previously entirely absent
- Optional daily budget cap: LLM calls are blocked and a `cost:budget-exceeded` IPC event is broadcast when the daily limit is hit
- IPC handlers (`cost:get-session-spend`, `cost:get-daily-spend`, `cost:set-daily-budget`, `cost:get-daily-budget`) exposed via `preload.ts`
- `CostDashboard.tsx` React component: session spend, daily spend, per-model breakdown table, budget gauge, and exceeded alert

## Changes

| File | Action |
|------|--------|
| `electron/services/CostPricer.ts` | CREATE — pricing table + `estimateCost()` pure function |
| `electron/services/MeetingCostTracker.ts` | CREATE — `llm_cost_log` SQLite table, per-meeting/daily queries, budget gate |
| `electron/services/IpcEventBus.ts` | UPDATE — add `cost:budget-exceeded` event type |
| `electron/LLMHelper.ts` | UPDATE — extract input/output tokens per provider; `setCostRecorder()`; budget pre-check in `chatWithGemini()` |
| `electron/ipc/costHandlers.ts` | CREATE — IPC handlers for spend queries + budget CRUD |
| `electron/services/CredentialsManager.ts` | UPDATE — `globalDailyBudgetCents` field + getter/setter |
| `electron/preload.ts` | UPDATE — `cost` API namespace (type + `exposeInMainWorld` block) |
| `electron/main.ts` | UPDATE — initialize `MeetingCostTracker`, wire to `LLMHelper`, register handlers, broadcast budget-exceeded |
| `electron/ipcHandlers.ts` | UPDATE — call `registerCostHandlers` in `initializeIpcHandlers()` |
| `src/components/CostDashboard.tsx` | CREATE — React component |
| `test/services/CostPricer.test.ts` | CREATE — 5 unit tests |
| `test/services/MeetingCostTracker.test.ts` | CREATE — 7 integration tests (SQLite in-memory) |
| `electron/services/BackgroundAgent.ts` | FIX — hoist `events`/`now` to method scope (TS scoping error surfaced during validation) |

## Deviations from plan

- **IPC handler registration**: Registered in `electron/ipcHandlers.ts` (where `registerDashboardHandlers` is actually called), not `main.ts` as the plan stated
- **Budget enforcement entry point**: Enforced at `chatWithGemini()` (the actual main dispatcher), not a `generate()` method (which doesn't exist)
- **Streaming methods**: Not updated — streaming chunks don't surface final usage metadata in this codebase; noted as a known gap

## Not built (scope limits)

- Historical cost charts / time-series graphs
- Per-request cost badge inline in chat UI
- Cost export / CSV download
- OpenRouter pricing (falls back to 0 with `console.warn`)
- DeepSeek (no active provider in `LLMHelper.ts`)
- Retroactive cost recalculation

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` (renderer) | ✅ |
| `npx tsc -p electron/tsconfig.json --noEmit` | ✅ |
| `npx vitest run test/services/CostPricer.test.ts` | ✅ 5 passed |
| `npx vitest run test/services/MeetingCostTracker.test.ts` | ✅ 7 passed |
| `npx vitest run` (full suite) | ✅ 429 passed, 0 failed (79 files) |
| `npm run build` | ✅ compiled in ~2.92s |

Fixes #12