### PR TITLE
feat(memory): add vector similarity search over memory graph

### DIFF
--- a/electron/ipc/memoryHandlers.ts
+++ b/electron/ipc/memoryHandlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { MemoryManager } from '../memory/MemoryManager';
 import { NodeKind } from '../memory/schema';
+import { AppState } from '../main';
 
 export function registerMemoryHandlers(): void {
   const mm = () => MemoryManager.getInstance();
@@ -28,4 +29,45 @@ export function registerMemoryHandlers(): void {
   ipcMain.handle('memory:resolve-review', (_event, id: number, approved: boolean) => {
     return mm().resolveReview(id, approved);
   });
+
+  ipcMain.handle(
+    'memory:find-similar',
+    async (_event, text: string, k: number = 5, kindFilter?: NodeKind) => {
+      if (typeof text !== 'string' || !text.trim()) return { error: 'text required' };
+      const appState = AppState.getInstance();
+      const ragManager = appState?.getRAGManager();
+      if (!ragManager) return { error: 'RAGManager not available' };
+      const pipeline = ragManager.getEmbeddingPipeline();
+      if (!pipeline.isReady()) return { error: 'EmbeddingPipeline not ready' };
+      try {
+        const queryVector = await pipeline.getEmbedding(text);
+        const results = mm().findSimilar(queryVector, k, kindFilter);
+        return { success: true, results };
+      } catch (err: any) {
+        console.error('[memory:find-similar]', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'memory:embed-fact',
+    async (_event, factId: number, text: string) => {
+      if (typeof factId !== 'number') return { error: 'factId must be a number' };
+      if (typeof text !== 'string' || !text.trim()) return { error: 'text required' };
+      const appState = AppState.getInstance();
+      const ragManager = appState?.getRAGManager();
+      if (!ragManager) return { error: 'RAGManager not available' };
+      const pipeline = ragManager.getEmbeddingPipeline();
+      if (!pipeline.isReady()) return { error: 'EmbeddingPipeline not ready' };
+      try {
+        const embedding = await pipeline.getEmbedding(text);
+        mm().storeFactEmbedding(factId, embedding);
+        return { success: true };
+      } catch (err: any) {
+        console.error('[memory:embed-fact]', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
 }

--- a/electron/memory/MemoryManager.ts
+++ b/electron/memory/MemoryManager.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { app } from 'electron';
 import crypto from 'crypto';
 import { runMigration } from './migration';
+import { loadSqliteVec } from './vecLoader';
 import {
   NodeKind,
   EdgePredicate,
@@ -40,6 +41,11 @@ export class MemoryManager {
         this.db = new Database(':memory:');
         this.degraded = true;
       }
+    }
+    try {
+      loadSqliteVec(this.db);
+    } catch (err) {
+      console.warn('[MemoryManager] sqlite-vec unavailable, vector search will be disabled:', err);
     }
     try {
       runMigration(this.db);
@@ -184,6 +190,60 @@ export class MemoryManager {
     ).run(nodeId, key, value, confidence, source);
 
     return this.db.prepare('SELECT * FROM memory_facts WHERE id = ?').get(Number(info.lastInsertRowid)) as MemoryFact;
+  }
+
+  /**
+   * Store a float32 embedding for a fact.
+   * Writes to both memory_facts.embedding (BLOB) and memory_facts_vec virtual table.
+   * No-op if the fact does not exist.
+   */
+  public storeFactEmbedding(factId: number, embedding: number[]): void {
+    const buf = Buffer.from(new Float32Array(embedding).buffer);
+    this.db.prepare(
+      "UPDATE memory_facts SET embedding = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(buf, factId);
+    try {
+      this.db.prepare(
+        'INSERT OR REPLACE INTO memory_facts_vec (fact_id, embedding) VALUES (?, ?)'
+      ).run(factId, new Float32Array(embedding));
+    } catch (err) {
+      console.warn('[MemoryManager] storeFactEmbedding: vec0 insert failed (extension unavailable?):', err);
+    }
+  }
+
+  /**
+   * Return the top-k memory facts whose embeddings are most similar to queryVector.
+   * Uses cosine distance via sqlite-vec vec0 KNN.
+   * Returns empty array if vec0 extension is unavailable.
+   */
+  public findSimilar(
+    queryVector: number[],
+    k: number = 5,
+    kindFilter?: NodeKind,
+  ): (MemoryFact & { node_label: string; node_kind: NodeKind; distance: number })[] {
+    try {
+      const queryBuf = new Float32Array(queryVector);
+      let sql = `
+        SELECT f.*, n.label AS node_label, n.kind AS node_kind, v.distance
+        FROM memory_facts_vec v
+        JOIN memory_facts f ON f.id = v.fact_id
+        JOIN memory_nodes n ON n.id = f.node_id
+        WHERE v.embedding MATCH ? AND k = ?
+      `;
+      const params: unknown[] = [queryBuf, k];
+
+      if (kindFilter) {
+        sql += ' AND n.kind = ?';
+        params.push(kindFilter);
+      }
+
+      sql += ' ORDER BY v.distance';
+
+      return this.db.prepare(sql).all(...params) as (MemoryFact & { node_label: string; node_kind: NodeKind; distance: number })[];
+    } catch (err) {
+      console.warn('[MemoryManager] findSimilar failed (sqlite-vec unavailable?):', err);
+      return [];
+    }
   }
 
   /**

--- a/electron/memory/migration.ts
+++ b/electron/memory/migration.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import { ALL_DDL, SCHEMA_VERSION } from './schema';
+import { ALL_DDL, VEC_DDL, SCHEMA_VERSION } from './schema';
 
 /**
  * Run memory-graph migrations idempotently.
@@ -20,6 +20,15 @@ export function runMigration(db: Database.Database): void {
       db.prepare('INSERT INTO memory_schema_version (version) VALUES (?)').run(SCHEMA_VERSION);
     }
   })();
+
+  // Vec-extension DDL runs separately — no-op if sqlite-vec is not loaded
+  for (const ddl of VEC_DDL) {
+    try {
+      db.exec(ddl);
+    } catch {
+      // sqlite-vec not loaded — vec0 tables will not be created
+    }
+  }
 }
 
 /**

--- a/electron/memory/schema.ts
+++ b/electron/memory/schema.ts
@@ -272,6 +272,13 @@ export const DDL_DECISIONS_MEETING_INDEX = `
 CREATE INDEX IF NOT EXISTS idx_decisions_meeting ON decisions(meeting_id);
 `;
 
+export const DDL_FACTS_VEC = `
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_facts_vec USING vec0(
+  fact_id INTEGER PRIMARY KEY,
+  embedding float[768] distance_metric=cosine
+);
+`;
+
 export interface Goal {
   id: string;
   title: string;
@@ -313,4 +320,9 @@ export const ALL_DDL = [
   DDL_DECISIONS,
   DDL_DECISIONS_GOAL_INDEX,
   DDL_DECISIONS_MEETING_INDEX,
+] as const;
+
+/** DDL that requires sqlite-vec extension to be loaded. Run separately after ALL_DDL. */
+export const VEC_DDL = [
+  DDL_FACTS_VEC,
 ] as const;

--- a/electron/memory/vecLoader.ts
+++ b/electron/memory/vecLoader.ts
@@ -1,0 +1,38 @@
+import Database from 'better-sqlite3';
+import { app } from 'electron';
+import path from 'path';
+
+/**
+ * Load the sqlite-vec extension into a better-sqlite3 database connection.
+ * In dev mode, uses the npm package loader. In production, resolves the
+ * platform-specific binary from the asar-unpacked path.
+ *
+ * Does NOT throw on failure — logs a warning and allows graceful degradation.
+ */
+export function loadSqliteVec(db: Database.Database): void {
+  try {
+    if (!app.isPackaged) {
+      // Dev mode: use the npm package's built-in loader
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const sqliteVec = require('sqlite-vec');
+      sqliteVec.load(db);
+    } else {
+      // Production: resolve platform binary from asar-unpacked
+      const platform = process.platform; // 'darwin', 'linux', 'win32'
+      const arch = process.arch; // 'arm64', 'x64'
+      const os = platform === 'win32' ? 'windows' : platform;
+      const ext = platform === 'darwin' ? 'dylib' : platform === 'win32' ? 'dll' : 'so';
+      const pkgName = `sqlite-vec-${os}-${arch}`;
+      const extPath = path.join(
+        process.resourcesPath,
+        'app.asar.unpacked',
+        'node_modules',
+        pkgName,
+        `vec0.${ext}`
+      );
+      db.loadExtension(extPath);
+    }
+  } catch (err) {
+    console.warn('[vecLoader] sqlite-vec unavailable, vector search will be disabled:', err);
+  }
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -236,6 +236,10 @@ interface ElectronAPI {
   goalList: () => Promise<Array<{ id: string; title: string; description: string; parent_id: string | null; created_at: number; completed_at: number | null }>>;
   goalComplete: (id: string) => Promise<{ success: boolean; error?: string }>;
   goalPreCallHint: (goalId: string) => Promise<Array<{ text: string; meeting_id: string; goal_id: string; meeting_date: string }>>;
+  memoryFindSimilar: (text: string, k?: number, kindFilter?: string) =>
+    Promise<{ success: true; results: Array<{ id: number; node_id: string; key: string; value: string; confidence: number; source: string; node_label: string; node_kind: string; distance: number }> } | { success: false; error: string } | { error: string }>;
+  memoryEmbedFact: (factId: number, text: string) =>
+    Promise<{ success: boolean; error?: string }>;
 }
 
 export const PROCESSING_EVENTS = {
@@ -922,4 +926,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   goalList: () => ipcRenderer.invoke('goal:list'),
   goalComplete: (id: string) => ipcRenderer.invoke('goal:complete', id),
   goalPreCallHint: (goalId: string) => ipcRenderer.invoke('goal:pre-call-hint', goalId),
+  memoryFindSimilar: (text: string, k?: number, kindFilter?: string) =>
+    ipcRenderer.invoke('memory:find-similar', text, k, kindFilter),
+  memoryEmbedFact: (factId: number, text: string) =>
+    ipcRenderer.invoke('memory:embed-fact', factId, text),
 } as ElectronAPI)

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "remark-math": "^6.0.0",
         "screenshot-desktop": "^1.15.0",
         "sharp": "^0.33.5",
+        "sqlite-vec": "^0.1.9",
         "sqlite3": "^5.1.7",
         "tailwind-merge": "^2.5.4",
         "tap": "^21.5.0",
@@ -20093,6 +20094,84 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "license": "MIT OR Apache",
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/sqlite3": {
       "version": "5.1.7",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,13 @@
         "to": "natively.icns"
       }
     ],
+    "asarUnpack": [
+      "**/node_modules/sqlite-vec-darwin-arm64/**",
+      "**/node_modules/sqlite-vec-darwin-x64/**",
+      "**/node_modules/sqlite-vec-linux-x64/**",
+      "**/node_modules/sqlite-vec-linux-arm64/**",
+      "**/node_modules/sqlite-vec-windows-x64/**"
+    ],
     "mac": {
       "category": "public.app-category.productivity",
       "target": [
@@ -166,6 +173,7 @@
     "@types/three": "^0.182.0",
     "axios": "^1.7.7",
     "better-sqlite3": "12.6.2",
+    "sqlite-vec": "^0.1.9",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "diff": "^7.0.0",

--- a/test/memory/VectorSearch.test.ts
+++ b/test/memory/VectorSearch.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { MemoryManager } from '../../electron/memory/MemoryManager';
+
+// Helper: encode number[] to Float32 Buffer (mirrors production code)
+function encodeVector(vec: number[]): Buffer {
+  return Buffer.from(new Float32Array(vec).buffer);
+}
+
+describe('VectorSearch', () => {
+  let db: Database.Database;
+  let mm: MemoryManager;
+
+  beforeEach(() => {
+    MemoryManager.resetInstance();
+    db = new Database(':memory:');
+    // Bypass vecLoader for tests (sqlite-vec not available in vitest env)
+    // runMigration is called inside MemoryManager constructor
+    mm = MemoryManager.getInstance(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    MemoryManager.resetInstance();
+  });
+
+  describe('storeFactEmbedding', () => {
+    it('writes BLOB to memory_facts.embedding', () => {
+      const node = mm.upsertNode('person', 'Alice');
+      const fact = mm.upsertFact(node.id, 'role', 'engineer');
+      const vec = Array.from({ length: 768 }, (_, i) => i / 768);
+
+      mm.storeFactEmbedding(fact.id, vec);
+
+      // The UPDATE for memory_facts should have been called
+      const row = db.prepare('SELECT embedding FROM memory_facts WHERE id = ?').get(fact.id) as any;
+      expect(row.embedding).toBeInstanceOf(Buffer);
+      expect(row.embedding.length).toBe(768 * 4); // Float32: 4 bytes each
+    });
+
+    it('does not throw when vec0 table unavailable (sqlite-vec not loaded)', () => {
+      const node = mm.upsertNode('topic', 'kubernetes');
+      const fact = mm.upsertFact(node.id, 'description', 'container orchestration');
+      const vec = Array.from({ length: 768 }, () => 0.1);
+      // Should not throw even if memory_facts_vec doesn't exist
+      expect(() => mm.storeFactEmbedding(fact.id, vec)).not.toThrow();
+    });
+  });
+
+  describe('findSimilar', () => {
+    it('returns empty array when vec0 unavailable (graceful degradation)', () => {
+      const node = mm.upsertNode('person', 'Bob');
+      mm.upsertFact(node.id, 'skill', 'TypeScript');
+      const queryVec = Array.from({ length: 768 }, () => 0.5);
+      // Without sqlite-vec loaded, memory_facts_vec doesn't exist -> should return []
+      const results = mm.findSimilar(queryVec, 5);
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
+    });
+
+    it('accepts optional kindFilter parameter without error', () => {
+      const queryVec = Array.from({ length: 768 }, () => 0.1);
+      expect(() => mm.findSimilar(queryVec, 3, 'person')).not.toThrow();
+    });
+
+    it('returns empty array for k=0', () => {
+      const queryVec = Array.from({ length: 768 }, () => 0.1);
+      const results = mm.findSimilar(queryVec, 0);
+      expect(results).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Wires up sqlite-vec KNN search over the existing `memory_facts` table. The `embedding BLOB` column was always NULL — facts were stored but semantically unsearchable. This PR adds the full read/write path:

- `memory_facts_vec` virtual table (vec0, cosine, 768d) created via schema migration
- `MemoryManager.storeFactEmbedding(factId, number[])` — writes Float32 BLOB to `memory_facts.embedding` and inserts into the vec0 virtual table
- `MemoryManager.findSimilar(queryVector, k, kindFilter?)` — KNN JOIN over `memory_facts_vec` + `memory_facts` + `memory_nodes`, returns top-k results with `node_label`, `node_kind`, and `distance`
- `memory:find-similar` and `memory:embed-fact` IPC handlers — embed query text via `EmbeddingPipeline` (Gemini `gemini-embedding-001`, 768d) then call into `MemoryManager`
- `window.electronAPI.memoryFindSimilar` and `memoryEmbedFact` renderer bindings

## Changes

| File | Action | Description |
|------|--------|-------------|
| `package.json` | UPDATE | Add `sqlite-vec ^0.1.9`; add `asarUnpack` for platform binaries |
| `electron/memory/vecLoader.ts` | CREATE | `loadSqliteVec(db)` — dev vs packaged path handling with graceful fallback |
| `electron/memory/schema.ts` | UPDATE | `DDL_FACTS_VEC` virtual table DDL; separate `VEC_DDL` array |
| `electron/memory/migration.ts` | UPDATE | Run vec DDL outside main transaction with per-statement try/catch (allows graceful skip when extension not loaded) |
| `electron/memory/MemoryManager.ts` | UPDATE | Load sqlite-vec in constructor; add `storeFactEmbedding` + `findSimilar` |
| `electron/ipc/memoryHandlers.ts` | UPDATE | Register `memory:find-similar` and `memory:embed-fact` handlers |
| `electron/preload.ts` | UPDATE | Extend `ElectronAPI` interface + add `contextBridge` bindings |
| `test/memory/VectorSearch.test.ts` | CREATE | 5 unit tests covering BLOB write, graceful degradation, and edge cases |

### Key design decisions

- **MemoryManager stays free of EmbeddingPipeline**: embedding is async; the IPC layer orchestrates embed → store, keeping `MemoryManager` synchronous and testable.
- **Vec DDL separated from ALL_DDL**: `VEC_DDL` runs outside the main migration transaction so existing tests (which don't load sqlite-vec) continue to pass. Extension unavailability is logged as a warning, not an error.
- **Graceful degradation throughout**: `loadSqliteVec` catches errors; `storeFactEmbedding` catches vec0 insert failure; `findSimilar` returns `[]` on any error.

## Validation

| Check | Result |
|-------|--------|
| `npx tsc -p electron/tsconfig.json --noEmit` | ✅ No errors |
| `npx vitest run test/memory/VectorSearch.test.ts` | ✅ 5/5 passed |
| `npx vitest run` (full suite) | ✅ 461/461 passed, 84 files, no regressions |
| `node -e "const v = require('sqlite-vec'); console.log(typeof v.load)"` | ✅ `function` |

Test environment note: sqlite-vec native extension is not loaded in vitest — tests cover the graceful-degradation path. The `storeFactEmbedding` BLOB write is tested via standard better-sqlite3 SELECT verification.

Fixes #1