### PR TITLE
feat(hermes): add HermesObserver meta-agent for cross-session pattern detection

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -137,6 +137,7 @@ export class AppState {
   private attendeeTracker: AttendeeTracker = new AttendeeTracker(this.lunrIndexer)
   private agentStateManager: AgentStateManager = new AgentStateManager()
   private backgroundAgent: BackgroundAgent | null = null
+  private hermesObserver: import('./services/HermesObserver').HermesObserver | null = null
   private dashboardPoller: DashboardPoller | null = null
   private dailySummaryScheduler: DailySummaryScheduler | null = null
   private proactiveAdviceEngine: ProactiveAdviceEngine | null = null
@@ -1264,6 +1265,10 @@ export class AppState {
     return this.backgroundAgent;
   }
 
+  public getHermesObserver(): import('./services/HermesObserver').HermesObserver | null {
+    return this.hermesObserver;
+  }
+
   public getDashboardPoller(): DashboardPoller | null {
     return this.dashboardPoller;
   }
@@ -1944,6 +1949,28 @@ async function initializeApp() {
       console.error('[Main] Failed to initialize CalendarManager:', e);
     }
 
+    // Start HermesObserver (meta-agent: cross-session pattern detector)
+    try {
+      const { HermesObserver } = require('./services/HermesObserver');
+      const { HermesDrafter } = require('./services/HermesDrafter');
+      const { CredentialsManager: CM } = require('./services/CredentialsManager');
+      const llmHelper = appState.processingHelper.getLLMHelper();
+      const hermesCfg = CM.getInstance().getHermesObserverConfig();
+      const hermesDrafter = new HermesDrafter(llmHelper);
+      const hermesObs = new HermesObserver(
+        appState['agentStateManager'],
+        hermesCfg.intervalMs,
+        hermesDrafter,
+      );
+      hermesObs.setEnabled(hermesCfg.enabled);
+      hermesObs.setSensitivity(hermesCfg.sensitivity);
+      appState['hermesObserver'] = hermesObs;
+      hermesObs.start();
+      console.log(`[Main] HermesObserver started (interval: ${hermesCfg.intervalMs}ms, sensitivity: ${hermesCfg.sensitivity})`);
+    } catch (hermesErr) {
+      console.error('[Main] Failed to start HermesObserver:', hermesErr);
+    }
+
     // Initialize Hermes orchestrator (Interpretation A — Inner Cluely Operator)
     try {
       const { HermesCore } = require('./hermes');
@@ -1985,6 +2012,37 @@ async function initializeApp() {
     ipcMain.handle('agent:get-settings', () => {
       const { CredentialsManager } = require('./services/CredentialsManager');
       return CredentialsManager.getInstance().getBackgroundAgentConfig();
+    });
+
+    // IPC: hermes:set-enabled
+    ipcMain.handle('hermes:set-enabled', (_event, enabled: boolean) => {
+      const { CredentialsManager } = require('./services/CredentialsManager');
+      CredentialsManager.getInstance().setHermesObserverEnabled(enabled);
+      appState.getHermesObserver()?.setEnabled(enabled);
+      return { enabled };
+    });
+
+    // IPC: hermes:set-sensitivity
+    ipcMain.handle('hermes:set-sensitivity', (_event, sensitivity: number) => {
+      const { CredentialsManager } = require('./services/CredentialsManager');
+      CredentialsManager.getInstance().setHermesObserverSensitivity(sensitivity);
+      appState.getHermesObserver()?.setSensitivity(sensitivity);
+      return { sensitivity };
+    });
+
+    // IPC: hermes:set-interval
+    ipcMain.handle('hermes:set-interval', (_event, ms: number) => {
+      const { CredentialsManager } = require('./services/CredentialsManager');
+      CredentialsManager.getInstance().setHermesObserverIntervalMs(ms);
+      const obs = appState.getHermesObserver();
+      if (obs) obs.setInterval(ms);
+      return { intervalMs: ms };
+    });
+
+    // IPC: hermes:get-settings
+    ipcMain.handle('hermes:get-settings', () => {
+      const { CredentialsManager } = require('./services/CredentialsManager');
+      return CredentialsManager.getInstance().getHermesObserverConfig();
     });
 
     // Recover unprocessed meetings (persistence check)

--- a/electron/services/BackgroundTriggerDrafter.ts
+++ b/electron/services/BackgroundTriggerDrafter.ts
@@ -12,7 +12,7 @@ export interface WorkflowDraft {
   goalTag: string | null;
   speaker: string;
   confidence: number;
-  source: 'background-email' | 'background-calendar' | 'background-staleness' | 'background-kb';
+  source: 'background-email' | 'background-calendar' | 'background-staleness' | 'background-kb' | 'hermes-pattern';
   tokensUsed: number;
 }
 

--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -40,6 +40,19 @@ export const DEFAULT_BG_AGENT_CONFIG: BackgroundAgentConfig = {
     intervalMs: 1800000,
     dailyBudgetCents: 10,
 };
+
+export interface HermesObserverConfig {
+    enabled: boolean;
+    intervalMs: number;
+    sensitivity: number;
+}
+
+export const DEFAULT_HERMES_CONFIG: HermesObserverConfig = {
+    enabled: true,
+    intervalMs: 6 * 60 * 60 * 1000,
+    sensitivity: 0.5,
+};
+
 export interface StoredCredentials {
     geminiApiKey?: string;
     groqApiKey?: string;
@@ -64,6 +77,7 @@ export interface StoredCredentials {
     openrouterModel?: string;
     exportWebhooks?: ExportWebhook[];
     backgroundAgent?: BackgroundAgentConfig;
+    hermesObserver?: HermesObserverConfig;
     globalDailyBudgetCents?: number;
 }
 
@@ -165,6 +179,10 @@ export class CredentialsManager {
 
     public getBackgroundAgentConfig(): BackgroundAgentConfig {
         return this.credentials.backgroundAgent ?? { ...DEFAULT_BG_AGENT_CONFIG };
+    }
+
+    public getHermesObserverConfig(): HermesObserverConfig {
+        return this.credentials.hermesObserver ?? { ...DEFAULT_HERMES_CONFIG };
     }
 
     public getAllCredentials(): StoredCredentials {
@@ -302,6 +320,22 @@ export class CredentialsManager {
         this.credentials.backgroundAgent.dailyBudgetCents = cents;
         this.saveCredentials();
         console.log(`[CredentialsManager] BackgroundAgent dailyBudgetCents: ${cents}`);
+    }
+
+    public setHermesObserverEnabled(enabled: boolean): void {
+        this.credentials.hermesObserver = { ...this.getHermesObserverConfig(), enabled };
+        this.saveCredentials();
+        console.log('[CredentialsManager] HermesObserver enabled:', enabled);
+    }
+
+    public setHermesObserverIntervalMs(ms: number): void {
+        this.credentials.hermesObserver = { ...this.getHermesObserverConfig(), intervalMs: ms };
+        this.saveCredentials();
+    }
+
+    public setHermesObserverSensitivity(s: number): void {
+        this.credentials.hermesObserver = { ...this.getHermesObserverConfig(), sensitivity: Math.max(0, Math.min(1, s)) };
+        this.saveCredentials();
     }
 
     public getGlobalDailyBudgetCents(): number | null {

--- a/electron/services/HermesDrafter.ts
+++ b/electron/services/HermesDrafter.ts
@@ -1,0 +1,75 @@
+import { v4 as uuidv4 } from 'uuid';
+import type { LLMHelper } from '../LLMHelper';
+import type { WorkflowDraft } from './BackgroundTriggerDrafter';
+
+export interface HermesPattern {
+  kind: 'recurring-blocker' | 'goal-drift' | 'contradiction';
+  label: string;
+  score: number;
+  occurrences?: number;
+  ageDays?: number;
+  oldValue?: string;
+  newValue?: string;
+}
+
+const HERMES_DRAFT_PROMPT = (trigger: string): string =>
+  `You are a meta-observation assistant. Given this cross-session pattern, produce a concise actionable workflow draft.
+Pattern: ${trigger}
+
+Respond in JSON only, no markdown, no explanation:
+{"title":"<short title>","templateId":"<one of: follow-up-email|code-task|research-task|meeting-schedule|document-update>","description":"<1-2 sentences>","steps":["step1","step2","step3"],"confidence":<0.0-1.0>}`;
+
+const TOKENS_PER_HERMES_DRAFT_ESTIMATE = 700;
+
+export class HermesDrafter {
+  constructor(private llmHelper: LLMHelper) {}
+
+  async draftFromRecurringBlocker(pattern: HermesPattern): Promise<WorkflowDraft | null> {
+    const trigger = `Recurring blocker detected: "${pattern.label}" has appeared as a blocker in ${pattern.occurrences} sessions`;
+    return this._draft(trigger, 'hermes-pattern');
+  }
+
+  async draftFromGoalDrift(pattern: HermesPattern): Promise<WorkflowDraft | null> {
+    const trigger = `Goal drift detected: goal "${pattern.label}" is ${pattern.ageDays} days old with no linked decisions`;
+    return this._draft(trigger, 'hermes-pattern');
+  }
+
+  async draftFromContradiction(pattern: HermesPattern): Promise<WorkflowDraft | null> {
+    const trigger = `Contradiction detected: "${pattern.label}" — agreed "${pattern.oldValue}" but later "${pattern.newValue}"`;
+    return this._draft(trigger, 'hermes-pattern');
+  }
+
+  private async _draft(
+    trigger: string,
+    source: WorkflowDraft['source'],
+  ): Promise<WorkflowDraft | null> {
+    try {
+      const raw = await this.llmHelper.chat(HERMES_DRAFT_PROMPT(trigger));
+      const parsed = JSON.parse(raw) as {
+        title: string;
+        templateId: string;
+        description: string;
+        steps: string[];
+        confidence: number;
+      };
+      return {
+        id: uuidv4(),
+        templateId: parsed.templateId ?? 'research-task',
+        payload: {
+          title: parsed.title,
+          description: parsed.description,
+          steps: parsed.steps ?? [],
+        },
+        kbCitations: [],
+        goalTag: null,
+        speaker: 'hermes-observer',
+        confidence: parsed.confidence ?? 0.7,
+        source,
+        tokensUsed: TOKENS_PER_HERMES_DRAFT_ESTIMATE,
+      };
+    } catch (err) {
+      console.warn('[HermesDrafter] Failed to draft:', err);
+      return null;
+    }
+  }
+}

--- a/electron/services/HermesObserver.ts
+++ b/electron/services/HermesObserver.ts
@@ -1,0 +1,163 @@
+import { BrowserWindow } from 'electron';
+import { AgentStateManager } from './AgentStateManager';
+import type { HermesDrafter, HermesPattern } from './HermesDrafter';
+import type { WorkflowDraft } from './BackgroundTriggerDrafter';
+import { MemoryManager } from '../memory/MemoryManager';
+
+export class HermesObserver {
+  private timer: NodeJS.Timeout | null = null;
+  private _intervalMs: number;
+  private _enabled: boolean = true;
+  private _sensitivity: number = 0.5;
+
+  constructor(
+    private stateManager: AgentStateManager,
+    intervalMs = 6 * 60 * 60 * 1000,
+    private drafter: HermesDrafter | null = null,
+  ) {
+    this._intervalMs = intervalMs;
+  }
+
+  start(intervalMs?: number): void {
+    if (intervalMs !== undefined) this._intervalMs = intervalMs;
+    this.stop();
+    this._runCycle().catch(() => {});
+    this.timer = setInterval(() => this._runCycle(), this._intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  setInterval(ms: number): void {
+    this._intervalMs = ms;
+    if (this.timer) {
+      this.stop();
+      this.start();
+    }
+  }
+
+  getIntervalMs(): number {
+    return this._intervalMs;
+  }
+
+  setEnabled(enabled: boolean): void { this._enabled = enabled; }
+  isEnabled(): boolean { return this._enabled; }
+  setSensitivity(s: number): void { this._sensitivity = Math.max(0, Math.min(1, s)); }
+  getSensitivity(): number { return this._sensitivity; }
+
+  async _runCycle(): Promise<void> {
+    if (!this._enabled) return;
+    if (this.stateManager.isPaused()) return;
+    try {
+      const patterns = this._detectPatterns();
+      const drafts: WorkflowDraft[] = [];
+      for (const pattern of patterns) {
+        if (pattern.score < this._sensitivity) continue;
+        if (!this.drafter) continue;
+        let draft: WorkflowDraft | null = null;
+        if (pattern.kind === 'recurring-blocker') draft = await this.drafter.draftFromRecurringBlocker(pattern);
+        else if (pattern.kind === 'goal-drift') draft = await this.drafter.draftFromGoalDrift(pattern);
+        else if (pattern.kind === 'contradiction') draft = await this.drafter.draftFromContradiction(pattern);
+        if (draft) drafts.push(draft);
+      }
+      if (drafts.length > 0) {
+        this._broadcast('approval:drafts-ready', { drafts });
+        console.log(`[HermesObserver] cycle complete, ${drafts.length} pattern insight(s) drafted`);
+      }
+    } catch (err) {
+      console.warn('[HermesObserver] cycle failed, will retry next interval:', err);
+    }
+  }
+
+  _detectPatterns(): HermesPattern[] {
+    try {
+      const db = MemoryManager.getInstance().getDb();
+      if (!db) return [];
+      const patterns: HermesPattern[] = [];
+
+      // Pattern 1 — Recurring Blockers
+      try {
+        const rows = db.prepare(`
+          SELECT n.label, COUNT(DISTINCT e.meeting_id) AS session_count
+          FROM memory_edges e
+          JOIN memory_nodes n ON n.id = e.target_id
+          WHERE e.predicate = 'blocked_by'
+          GROUP BY e.target_id
+          HAVING session_count >= 2
+        `).all() as Array<{ label: string; session_count: number }>;
+
+        for (const row of rows) {
+          patterns.push({
+            kind: 'recurring-blocker',
+            label: row.label,
+            score: Math.min(1, row.session_count / 5),
+            occurrences: row.session_count,
+          });
+        }
+      } catch { /* table may not exist yet */ }
+
+      // Pattern 2 — Goal Drift
+      try {
+        const cutoff = Math.floor((Date.now() - 14 * 24 * 60 * 60 * 1000) / 1000);
+        const goals = db.prepare(`
+          SELECT g.title, (unixepoch() - g.created_at) / 86400 AS age_days
+          FROM goals g
+          WHERE g.completed_at IS NULL
+            AND g.created_at < ?
+            AND NOT EXISTS (SELECT 1 FROM decisions d WHERE d.goal_id = g.id)
+        `).all(cutoff) as Array<{ title: string; age_days: number }>;
+
+        for (const g of goals) {
+          patterns.push({
+            kind: 'goal-drift',
+            label: g.title,
+            score: Math.min(1, g.age_days / 60),
+            ageDays: g.age_days,
+          });
+        }
+      } catch { /* table may not exist yet */ }
+
+      // Pattern 3 — Unresolved Contradictions
+      try {
+        const conflicts = db.prepare(`
+          SELECT entity, old_value, new_value
+          FROM pending_conflicts
+          WHERE resolved_at IS NULL
+          ORDER BY created_at DESC
+          LIMIT 10
+        `).all() as Array<{ entity: string; old_value: string; new_value: string }>;
+
+        for (const c of conflicts) {
+          patterns.push({
+            kind: 'contradiction',
+            label: c.entity,
+            score: 0.6,
+            oldValue: c.old_value,
+            newValue: c.new_value,
+          });
+        }
+      } catch { /* table may not exist yet */ }
+
+      return patterns;
+    } catch {
+      // MemoryManager not initialized yet
+      return [];
+    }
+  }
+
+  private _broadcast(channel: string, data: unknown): void {
+    BrowserWindow.getAllWindows().forEach(win => {
+      if (!win.isDestroyed()) {
+        win.webContents.send(channel, data);
+      }
+    });
+  }
+
+  dispose(): void {
+    this.stop();
+  }
+}

--- a/test/services/HermesDrafter.test.ts
+++ b/test/services/HermesDrafter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HermesDrafter } from '../../electron/services/HermesDrafter';
+import type { LLMHelper } from '../../electron/LLMHelper';
+
+const mockLLM = {
+  chat: vi.fn().mockResolvedValue(
+    '{"title":"Address recurring blocker","templateId":"research-task","description":"Investigate recurring issue","steps":["Identify root cause","Propose fix","Schedule review"],"confidence":0.8}'
+  ),
+} as unknown as LLMHelper;
+
+describe('HermesDrafter', () => {
+  it('draftFromRecurringBlocker returns draft with source hermes-pattern', async () => {
+    const drafter = new HermesDrafter(mockLLM);
+    const draft = await drafter.draftFromRecurringBlocker({
+      kind: 'recurring-blocker',
+      label: 'auth-service',
+      score: 0.8,
+      occurrences: 4,
+    });
+    expect(draft).not.toBeNull();
+    expect(draft!.source).toBe('hermes-pattern');
+  });
+
+  it('draftFromGoalDrift returns draft with source hermes-pattern', async () => {
+    const drafter = new HermesDrafter(mockLLM);
+    const draft = await drafter.draftFromGoalDrift({
+      kind: 'goal-drift',
+      label: 'Launch v2',
+      score: 0.6,
+      ageDays: 35,
+    });
+    expect(draft).not.toBeNull();
+    expect(draft!.source).toBe('hermes-pattern');
+  });
+
+  it('draftFromContradiction returns draft with source hermes-pattern', async () => {
+    const drafter = new HermesDrafter(mockLLM);
+    const draft = await drafter.draftFromContradiction({
+      kind: 'contradiction',
+      label: 'pricing-model',
+      score: 0.6,
+      oldValue: 'flat fee',
+      newValue: 'usage-based',
+    });
+    expect(draft).not.toBeNull();
+    expect(draft!.source).toBe('hermes-pattern');
+  });
+
+  it('returns null when LLM returns invalid JSON', async () => {
+    const badLLM = { chat: vi.fn().mockResolvedValue('not json at all') } as unknown as LLMHelper;
+    const drafter = new HermesDrafter(badLLM);
+    const draft = await drafter.draftFromRecurringBlocker({
+      kind: 'recurring-blocker',
+      label: 'x',
+      score: 0.9,
+      occurrences: 5,
+    });
+    expect(draft).toBeNull();
+  });
+
+  it('speaker is hermes-observer', async () => {
+    const drafter = new HermesDrafter(mockLLM);
+    const draft = await drafter.draftFromRecurringBlocker({
+      kind: 'recurring-blocker',
+      label: 'test',
+      score: 0.7,
+      occurrences: 3,
+    });
+    expect(draft!.speaker).toBe('hermes-observer');
+  });
+});

--- a/test/services/HermesObserver.test.ts
+++ b/test/services/HermesObserver.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { HermesObserver } from '../../electron/services/HermesObserver';
+import { AgentStateManager } from '../../electron/services/AgentStateManager';
+import { IpcEventBus } from '../../electron/services/IpcEventBus';
+import { BrowserWindow } from 'electron';
+import type { HermesDrafter, HermesPattern } from '../../electron/services/HermesDrafter';
+
+const mockSend = vi.fn();
+vi.spyOn(BrowserWindow, 'getAllWindows').mockReturnValue([
+  { isDestroyed: () => false, webContents: { send: mockSend } } as any,
+]);
+
+function createMockDrafter(): HermesDrafter {
+  return {
+    draftFromRecurringBlocker: vi.fn().mockResolvedValue({
+      id: 'draft-1',
+      templateId: 'research-task',
+      payload: { title: 'Recurring blocker', description: 'Test', steps: ['step1'] },
+      kbCitations: [],
+      goalTag: null,
+      speaker: 'hermes-observer',
+      confidence: 0.8,
+      source: 'hermes-pattern',
+      tokensUsed: 700,
+    }),
+    draftFromGoalDrift: vi.fn().mockResolvedValue({
+      id: 'draft-2',
+      templateId: 'research-task',
+      payload: { title: 'Goal drift', description: 'Test', steps: ['step1'] },
+      kbCitations: [],
+      goalTag: null,
+      speaker: 'hermes-observer',
+      confidence: 0.7,
+      source: 'hermes-pattern',
+      tokensUsed: 700,
+    }),
+    draftFromContradiction: vi.fn().mockResolvedValue({
+      id: 'draft-3',
+      templateId: 'research-task',
+      payload: { title: 'Contradiction', description: 'Test', steps: ['step1'] },
+      kbCitations: [],
+      goalTag: null,
+      speaker: 'hermes-observer',
+      confidence: 0.6,
+      source: 'hermes-pattern',
+      tokensUsed: 700,
+    }),
+  } as unknown as HermesDrafter;
+}
+
+describe('HermesObserver', () => {
+  let stateManager: AgentStateManager;
+  let observer: HermesObserver;
+  let drafter: HermesDrafter;
+
+  beforeEach(() => {
+    mockSend.mockClear();
+    stateManager = new AgentStateManager();
+    drafter = createMockDrafter();
+    observer = new HermesObserver(stateManager, 60000, drafter);
+  });
+
+  afterEach(() => {
+    observer.stop();
+    stateManager.dispose();
+  });
+
+  it('skips cycle when disabled', async () => {
+    observer.setEnabled(false);
+    vi.spyOn(observer as any, '_detectPatterns').mockReturnValue([
+      { kind: 'recurring-blocker', label: 'auth-service', score: 0.8, occurrences: 4 },
+    ]);
+    await observer._runCycle();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('skips cycle when paused (meeting active)', async () => {
+    IpcEventBus.emitTyped('meeting:started', { meeting_id: 'test-meeting' });
+    vi.spyOn(observer as any, '_detectPatterns').mockReturnValue([
+      { kind: 'recurring-blocker', label: 'auth-service', score: 0.8, occurrences: 4 },
+    ]);
+    await observer._runCycle();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts approval:drafts-ready when drafter produces draft for recurring blocker', async () => {
+    vi.spyOn(observer as any, '_detectPatterns').mockReturnValue([
+      { kind: 'recurring-blocker', label: 'auth-service', score: 0.8, occurrences: 4 },
+    ]);
+    await observer._runCycle();
+    expect(mockSend).toHaveBeenCalledWith('approval:drafts-ready', expect.objectContaining({
+      drafts: expect.arrayContaining([expect.objectContaining({ source: 'hermes-pattern' })]),
+    }));
+  });
+
+  it('sensitivity gate: skips patterns below threshold', async () => {
+    observer.setSensitivity(0.5);
+    vi.spyOn(observer as any, '_detectPatterns').mockReturnValue([
+      { kind: 'recurring-blocker', label: 'low-score', score: 0.3, occurrences: 1 },
+    ]);
+    await observer._runCycle();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('sensitivity gate: surfaces patterns at or above threshold', async () => {
+    observer.setSensitivity(0.5);
+    vi.spyOn(observer as any, '_detectPatterns').mockReturnValue([
+      { kind: 'recurring-blocker', label: 'auth-service', score: 0.5, occurrences: 3 },
+    ]);
+    await observer._runCycle();
+    expect(mockSend).toHaveBeenCalledWith('approval:drafts-ready', expect.anything());
+  });
+
+  it('swallows errors in _runCycle and does not throw', async () => {
+    const throwingDrafter = {
+      draftFromRecurringBlocker: vi.fn().mockRejectedValue(new Error('LLM down')),
+      draftFromGoalDrift: vi.fn(),
+      draftFromContradiction: vi.fn(),
+    } as unknown as HermesDrafter;
+    const obs = new HermesObserver(stateManager, 60000, throwingDrafter);
+    vi.spyOn(obs as any, '_detectPatterns').mockReturnValue([
+      { kind: 'recurring-blocker', label: 'x', score: 0.9, occurrences: 5 },
+    ]);
+    // Should not throw
+    await expect(obs._runCycle()).resolves.toBeUndefined();
+    obs.stop();
+  });
+
+  it('setInterval/getIntervalMs round-trip', () => {
+    observer.start(30000);
+    observer.setInterval(120000);
+    expect(observer.getIntervalMs()).toBe(120000);
+  });
+
+  it('stop() clears timer', () => {
+    observer.start();
+    expect((observer as any).timer).not.toBeNull();
+    observer.stop();
+    expect((observer as any).timer).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `HermesObserver`, a persistent polling service that queries `memory.db` every 6 hours to detect cross-session patterns: recurring blockers, stale goals with no linked decisions, and unresolved contradictions.
- Adds `HermesDrafter`, an LLM drafter that converts detected patterns into `WorkflowDraft` objects with `source: 'hermes-pattern'`.
- Extends `CredentialsManager` with `HermesObserverConfig` (enabled, intervalMs, sensitivity) and 4 new IPC handlers (`hermes:set-enabled`, `hermes:set-sensitivity`, `hermes:set-interval`, `hermes:get-settings`).
- Integrates into `AppState` in `electron/main.ts` following the exact `BackgroundAgent` pattern.
- Observations surface in the existing Pending Workflows tray (`approval:drafts-ready`) — never auto-executed.

## Changes

| File | Action | Details |
|------|--------|---------|
| `electron/services/BackgroundTriggerDrafter.ts` | UPDATE | Add `'hermes-pattern'` to `WorkflowDraft.source` union |
| `electron/services/HermesDrafter.ts` | CREATE | LLM drafter for 3 pattern types (recurring-blocker, goal-drift, contradiction) |
| `electron/services/HermesObserver.ts` | CREATE | Observer service with `_detectPatterns()` (3 SQLite queries), sensitivity gate, `_runCycle()`, `_broadcast()` |
| `electron/services/CredentialsManager.ts` | UPDATE | `HermesObserverConfig` interface, `DEFAULT_HERMES_CONFIG`, getter + 3 setters |
| `electron/main.ts` | UPDATE | `hermesObserver` field, `getHermesObserver()` getter, instantiation block, 4 IPC handlers |
| `test/services/HermesObserver.test.ts` | CREATE | 8 unit tests: disabled gate, paused gate, sensitivity gate (below/at threshold), broadcast, error swallow, interval round-trip, stop |
| `test/services/HermesDrafter.test.ts` | CREATE | 5 unit tests: each draft method, null-on-bad-json, source field, speaker field |

## Architecture

`HermesObserver` mirrors `BackgroundAgent` structurally: `start/stop/setInterval/getIntervalMs/dispose` lifecycle, `_runCycle` with enabled+paused gates, `_broadcast` via `BrowserWindow.getAllWindows()`. The service is synchronous at query time (better-sqlite3) and async at draft time (LLM call).

The 3 SQLite pattern queries:
1. **Recurring blockers** — `blocked_by` edges across ≥2 distinct `meeting_id`s; score = `min(1, session_count / 5)`
2. **Goal drift** — open goals older than 14 days with zero linked decisions; score = `min(1, age_days / 60)`
3. **Unresolved contradictions** — rows in `pending_conflicts` where `resolved_at IS NULL`; score = `0.6`

Sensitivity gate: patterns with `score < sensitivity` are silently skipped. Default sensitivity is `0.5`.

No new DB tables. No renderer changes. No auto-execution.

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` (frontend) | ✅ 0 errors |
| `npx tsc -p electron/tsconfig.json --noEmit` | ✅ 0 errors |
| `npx vitest run` | ✅ 494 passed, 0 failed (88 test files) |
| `npm run build` | ✅ compiled successfully |

Notable deviations from plan:
- Tests use `IpcEventBus.emitTyped('meeting:started', ...)` to trigger paused state (no public `.pause()` API on `AgentStateManager`).
- Used `const { CredentialsManager: CM } = require(...)` alias in `main.ts` instantiation block to avoid redeclaration error.

Fixes #26