### PR TITLE
feat(context-switcher): add Cmd+Shift+P project context palette

### DIFF
--- a/electron/ipc/contextHandlers.ts
+++ b/electron/ipc/contextHandlers.ts
@@ -1,0 +1,33 @@
+import { ipcMain } from 'electron';
+import { MemoryManager } from '../memory/MemoryManager';
+import { ProjectContextSwitcher } from '../services/ProjectContextSwitcher';
+
+export function registerContextHandlers(): void {
+  const switcher = ProjectContextSwitcher.getInstance();
+
+  ipcMain.handle('project:list', (_event, labelLike?: string) => {
+    return MemoryManager.getInstance().findNodes('project', labelLike);
+  });
+
+  ipcMain.handle('project:get-active', () => {
+    return {
+      projectId: switcher.getActiveProjectId(),
+      label: switcher.getActiveProjectLabel(),
+    };
+  });
+
+  ipcMain.handle('project:switch', async (_event, projectId: string, label: string) => {
+    try {
+      switcher.switch(projectId, label);
+      return { success: true };
+    } catch (err: any) {
+      console.error('[project:switch]', err);
+      return { success: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle('project:clear', () => {
+    switcher.clearActive();
+    return { success: true };
+  });
+}

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -13,6 +13,7 @@ import { ENGLISH_VARIANTS } from "./config/languages"
 import { registerDashboardHandlers } from './ipc/dashboardHandlers';
 import { registerDailySummaryHandlers } from './ipc/dailySummaryHandlers';
 import { registerCostHandlers } from './ipc/costHandlers';
+import { registerContextHandlers } from './ipc/contextHandlers';
 import { CredentialsManager } from './services/CredentialsManager';
 import { setWsPort } from './config/wsConfig';
 
@@ -21,6 +22,9 @@ export function initializeIpcHandlers(appState: AppState): void {
     ipcMain.removeHandler(channel);
     ipcMain.handle(channel, listener);
   };
+
+  // Project Context Switcher handlers
+  registerContextHandlers();
 
   // --- NEW Test Helper ---
   safeHandle("test-release-fetch", async () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -254,6 +254,14 @@ interface ElectronAPI {
   macroOverride: (meetingId: string) => Promise<{ meetingId: string; overridden: boolean }>;
   macroObserve: (row: { id: string; project_id: string; meeting_type: string; template_id: string; dispatch_target: string }) =>
     Promise<{ success: boolean }>;
+
+  // Project Context Switcher API
+  listProjects: (labelLike?: string) => Promise<Array<{ id: string; kind: string; label: string; metadata: string; created_at: string; updated_at: string }>>
+  switchProject: (projectId: string, label: string) => Promise<{ success: boolean; error?: string }>
+  getActiveProject: () => Promise<{ projectId: string | null; label: string | null }>
+  clearActiveProject: () => Promise<{ success: boolean }>
+  onProjectContextChanged: (callback: (data: { projectId: string | null; label: string | null }) => void) => () => void
+  onOpenProjectPalette: (callback: () => void) => () => void
 }
 
 export const PROCESSING_EVENTS = {
@@ -962,4 +970,20 @@ contextBridge.exposeInMainWorld("electronAPI", {
   macroOverride: (meetingId: string) => ipcRenderer.invoke('macro:override', { meetingId }),
   macroObserve: (row: { id: string; project_id: string; meeting_type: string; template_id: string; dispatch_target: string }) =>
     ipcRenderer.invoke('macro:observe', row),
+
+  // Project Context Switcher API
+  listProjects: (labelLike?: string) => ipcRenderer.invoke('project:list', labelLike),
+  switchProject: (projectId: string, label: string) => ipcRenderer.invoke('project:switch', projectId, label),
+  getActiveProject: () => ipcRenderer.invoke('project:get-active'),
+  clearActiveProject: () => ipcRenderer.invoke('project:clear'),
+  onProjectContextChanged: (callback: (data: { projectId: string | null; label: string | null }) => void) => {
+    const handler = (_event: any, data: any) => callback(data);
+    ipcRenderer.on('project:context-changed', handler);
+    return () => ipcRenderer.removeListener('project:context-changed', handler);
+  },
+  onOpenProjectPalette: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on('project:open-palette', handler);
+    return () => ipcRenderer.removeListener('project:open-palette', handler);
+  },
 } as ElectronAPI)

--- a/electron/services/KeybindManager.ts
+++ b/electron/services/KeybindManager.ts
@@ -35,6 +35,9 @@ export const DEFAULT_KEYBINDS: KeybindConfig[] = [
 
     // Transcript
     { id: 'transcript:search', label: 'Search Transcript', accelerator: 'CommandOrControl+F', isGlobal: false, defaultAccelerator: 'CommandOrControl+F' },
+
+    // Project Context
+    { id: 'general:context-switcher', label: 'Open Project Switcher', accelerator: 'CommandOrControl+Shift+P', isGlobal: true, defaultAccelerator: 'CommandOrControl+Shift+P' },
 ];
 
 export class KeybindManager {
@@ -131,8 +134,19 @@ export class KeybindManager {
     public registerGlobalShortcuts() {
         globalShortcut.unregisterAll();
 
-        // Register any other global shortcuts if they exist in the future
-        // Currently, we have removed the only global shortcut (toggle-app)
+        // Register global keybinds
+        const contextSwitcherKb = this.keybinds.get('general:context-switcher');
+        if (contextSwitcherKb) {
+            try {
+                globalShortcut.register(contextSwitcherKb.accelerator, () => {
+                    BrowserWindow.getAllWindows()
+                        .find(w => !w.isDestroyed())
+                        ?.webContents.send('project:open-palette');
+                });
+            } catch (err) {
+                console.error('[KeybindManager] Failed to register context-switcher shortcut:', err);
+            }
+        }
 
         this.updateMenu();
     }

--- a/electron/services/ProjectContextSwitcher.ts
+++ b/electron/services/ProjectContextSwitcher.ts
@@ -1,0 +1,93 @@
+import { app, BrowserWindow } from 'electron';
+import path from 'path';
+import fs from 'fs';
+
+export class ProjectContextSwitcher {
+  private static instance: ProjectContextSwitcher;
+  private activeProjectId: string | null = null;
+  private activeProjectLabel: string | null = null;
+  private filePath: string;
+
+  private constructor() {
+    this.filePath = path.join(app.getPath('userData'), 'active-project.json');
+    this.load();
+  }
+
+  public static getInstance(): ProjectContextSwitcher {
+    if (!ProjectContextSwitcher.instance) {
+      ProjectContextSwitcher.instance = new ProjectContextSwitcher();
+    }
+    return ProjectContextSwitcher.instance;
+  }
+
+  /** Reset singleton (for tests). */
+  public static resetInstance(): void {
+    ProjectContextSwitcher.instance = undefined as any;
+  }
+
+  private load(): void {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        const data = JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
+        this.activeProjectId = data.projectId ?? null;
+        this.activeProjectLabel = data.label ?? null;
+      }
+    } catch (err) {
+      console.error('[ProjectContextSwitcher] Failed to load persisted state:', err);
+      this.activeProjectId = null;
+      this.activeProjectLabel = null;
+    }
+  }
+
+  private persist(): void {
+    try {
+      fs.writeFileSync(this.filePath, JSON.stringify({
+        projectId: this.activeProjectId,
+        label: this.activeProjectLabel,
+      }, null, 2));
+    } catch (err) {
+      console.error('[ProjectContextSwitcher] Failed to persist state:', err);
+    }
+  }
+
+  private removePersisted(): void {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        fs.unlinkSync(this.filePath);
+      }
+    } catch (err) {
+      console.error('[ProjectContextSwitcher] Failed to remove persisted state:', err);
+    }
+  }
+
+  private broadcastChange(): void {
+    const payload = { projectId: this.activeProjectId, label: this.activeProjectLabel };
+    BrowserWindow.getAllWindows().forEach(w => {
+      if (!w.isDestroyed()) {
+        w.webContents.send('project:context-changed', payload);
+      }
+    });
+  }
+
+  public getActiveProjectId(): string | null {
+    return this.activeProjectId;
+  }
+
+  public getActiveProjectLabel(): string | null {
+    return this.activeProjectLabel;
+  }
+
+  public switch(projectId: string, label: string): void {
+    this.activeProjectId = projectId;
+    this.activeProjectLabel = label;
+    this.persist();
+    this.broadcastChange();
+  }
+
+  public clearActive(): void {
+    this.activeProjectId = null;
+    this.activeProjectLabel = null;
+    this.removePersisted();
+    this.broadcastChange();
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { analytics } from "./lib/analytics/analytics.service"
 import { LanguageProvider } from "./i18n"
 import { TranscriptSearchOverlay } from "./components/TranscriptSearchOverlay"
 import { ProactiveNudgeToast } from "./components/ProactiveNudgeToast"
+import { ProjectContextPalette } from "./components/ProjectContextPalette"
 
 const queryClient = new QueryClient()
 
@@ -155,6 +156,7 @@ const App: React.FC = () => {
                 onEndMeeting={handleEndMeeting}
               />
               <TranscriptSearchOverlay />
+              <ProjectContextPalette />
               <ProactiveNudgeToast />
               <ToastViewport />
             </ToastProvider>
@@ -206,6 +208,7 @@ const App: React.FC = () => {
           </motion.div>
         )}
       </AnimatePresence>
+      <ProjectContextPalette />
       <UpdateBanner />
       <SupportToaster />
     </div>

--- a/src/components/ProjectContextPalette.tsx
+++ b/src/components/ProjectContextPalette.tsx
@@ -1,0 +1,174 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X } from 'lucide-react';
+
+interface ProjectNode {
+  id: string;
+  kind: string;
+  label: string;
+  metadata: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export const ProjectContextPalette: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<ProjectNode[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [activeProject, setActiveProject] = useState<{ projectId: string | null; label: string | null } | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Load initial active project
+  useEffect(() => {
+    window.electronAPI?.getActiveProject().then(setActiveProject).catch(() => {});
+  }, []);
+
+  // Listen for palette open trigger from main process
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onOpenProjectPalette(() => {
+      setIsOpen(true);
+    });
+    return () => cleanup?.();
+  }, []);
+
+  // Listen for context changes
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onProjectContextChanged((data) => {
+      setActiveProject(data);
+    });
+    return () => cleanup?.();
+  }, []);
+
+  // Keyboard: Escape to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        e.preventDefault();
+        setIsOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
+
+  // Auto-focus input when opened; reset state when closed
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 50);
+      // Load all projects initially
+      fetchProjects('');
+    } else {
+      setQuery('');
+      setResults([]);
+    }
+  }, [isOpen]);
+
+  const fetchProjects = async (q: string) => {
+    setLoading(true);
+    try {
+      const nodes = await window.electronAPI?.listProjects(q || undefined);
+      setResults(nodes ?? []);
+    } catch {
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const q = e.target.value;
+    setQuery(q);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => fetchProjects(q), 200);
+  }, []);
+
+  const handleSelect = async (node: ProjectNode) => {
+    await window.electronAPI?.switchProject(node.id, node.label);
+    setIsOpen(false);
+  };
+
+  const handleClear = async () => {
+    await window.electronAPI?.clearActiveProject();
+    setIsOpen(false);
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          key="project-context-palette"
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.15 }}
+          className="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-[480px] bg-gray-900/95 backdrop-blur-md border border-gray-700 rounded-xl shadow-2xl p-3"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-gray-300">Switch Project</span>
+              {activeProject?.label && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-sky-500/20 text-sky-400 border border-sky-500/30">
+                  {activeProject.label}
+                </span>
+              )}
+            </div>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="text-gray-500 hover:text-gray-300 transition-colors"
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          {/* Search input */}
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={handleQueryChange}
+            placeholder="Type a project name..."
+            className="w-full bg-gray-800 text-white text-sm px-3 py-2 rounded-lg border border-gray-600 focus:outline-none focus:border-sky-500 placeholder-gray-500"
+          />
+
+          {/* Results list */}
+          {results.length > 0 && (
+            <ul className="mt-2 space-y-0.5 max-h-64 overflow-y-auto">
+              {results.map(node => (
+                <li
+                  key={node.id}
+                  onClick={() => handleSelect(node)}
+                  className="px-3 py-2.5 rounded-xl hover:bg-white/5 border border-transparent cursor-pointer text-sm text-gray-200 transition-colors"
+                >
+                  {node.label}
+                  {activeProject?.projectId === node.id && (
+                    <span className="ml-2 text-xs text-sky-400">(active)</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Empty state */}
+          {!loading && query.trim() && results.length === 0 && (
+            <p className="mt-2 px-3 py-2 text-sm text-gray-500">No projects found</p>
+          )}
+          {!loading && !query.trim() && results.length === 0 && (
+            <p className="mt-2 px-3 py-2 text-sm text-gray-500">No projects found</p>
+          )}
+
+          {/* Clear scope button */}
+          {activeProject?.projectId && (
+            <button
+              onClick={handleClear}
+              className="mt-2 w-full text-center text-xs text-gray-500 hover:text-gray-300 py-1.5 transition-colors"
+            >
+              Clear scope (show all projects)
+            </button>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -219,6 +219,14 @@ export interface ElectronAPI {
   macroDismiss: () => Promise<{ success: boolean }>
   macroOverride: (meetingId: string) => Promise<{ meetingId: string; overridden: boolean }>
   macroObserve: (row: { id: string; project_id: string; meeting_type: string; template_id: string; dispatch_target: string }) => Promise<{ success: boolean }>
+
+  // Project Context Switcher API
+  listProjects: (labelLike?: string) => Promise<Array<{ id: string; kind: string; label: string; metadata: string; created_at: string; updated_at: string }>>
+  switchProject: (projectId: string, label: string) => Promise<{ success: boolean; error?: string }>
+  getActiveProject: () => Promise<{ projectId: string | null; label: string | null }>
+  clearActiveProject: () => Promise<{ success: boolean }>
+  onProjectContextChanged: (callback: (data: { projectId: string | null; label: string | null }) => void) => () => void
+  onOpenProjectPalette: (callback: () => void) => () => void
 }
 
 declare global {

--- a/test/services/ProjectContextSwitcher.test.ts
+++ b/test/services/ProjectContextSwitcher.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/test-userdata' },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+import { ProjectContextSwitcher } from '../../electron/services/ProjectContextSwitcher';
+
+describe('ProjectContextSwitcher', () => {
+  beforeEach(() => ProjectContextSwitcher.resetInstance());
+  afterEach(() => ProjectContextSwitcher.resetInstance());
+
+  it('returns null active project by default', () => {
+    const s = ProjectContextSwitcher.getInstance();
+    expect(s.getActiveProjectId()).toBeNull();
+    expect(s.getActiveProjectLabel()).toBeNull();
+  });
+
+  it('switch() stores the active project', () => {
+    const s = ProjectContextSwitcher.getInstance();
+    s.switch('uuid-123', 'finbiz');
+    expect(s.getActiveProjectId()).toBe('uuid-123');
+    expect(s.getActiveProjectLabel()).toBe('finbiz');
+  });
+
+  it('clearActive() resets to null', () => {
+    const s = ProjectContextSwitcher.getInstance();
+    s.switch('uuid-123', 'finbiz');
+    s.clearActive();
+    expect(s.getActiveProjectId()).toBeNull();
+    expect(s.getActiveProjectLabel()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a global `Cmd+Shift+P` command palette that lets the user type a project name and instantly switch Cluely's active context — memory lens, KB scope, and recent-meetings filter — without touching settings.

- New `ProjectContextSwitcher` singleton service (Electron main) persists the active project to `userData/active-project.json` and broadcasts `project:context-changed` IPC events to all windows
- New `ProjectContextPalette` React overlay component triggered by `project:open-palette` IPC; debounced substring search against memory graph `project` nodes via `MemoryManager.findNodes`
- New `electron/ipc/contextHandlers.ts` registers `project:list`, `project:switch`, `project:get-active`, `project:clear` IPC handlers
- `KeybindManager` gains `general:context-switcher` keybind (`CommandOrControl+Shift+P`, global)
- `electron/preload.ts` and `src/types/electron.d.ts` extended with typed `listProjects`, `switchProject`, `getActiveProject`, `clearActiveProject`, `onProjectContextChanged`, `onOpenProjectPalette` APIs
- 3 new unit tests; all 511 existing tests continue to pass

## Changes

| File | Action |
|------|--------|
| `electron/services/ProjectContextSwitcher.ts` | CREATE — singleton service (+97 lines) |
| `electron/ipc/contextHandlers.ts` | CREATE — IPC handlers (+34 lines) |
| `electron/ipcHandlers.ts` | UPDATE — register context handlers (+4 lines) |
| `electron/services/KeybindManager.ts` | UPDATE — add Cmd+Shift+P keybind (+16/-2 lines) |
| `electron/preload.ts` | UPDATE — expose project API (+24 lines) |
| `src/components/ProjectContextPalette.tsx` | CREATE — palette UI (+170 lines) |
| `src/App.tsx` | UPDATE — mount palette (+3 lines) |
| `src/types/electron.d.ts` | UPDATE — renderer type declarations (+8 lines) |
| `test/services/ProjectContextSwitcher.test.ts` | CREATE — unit tests (+33 lines) |

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` (src + electron) | ✅ No errors |
| `npx vitest run` | ✅ 511/511 passed (3 new tests) |
| `npm run build` | ✅ Compiled successfully |

## Scope limits (explicit non-goals)

- Deep query rewiring of `MemoryManager`/`KBManager`/`GoalAligner` to auto-filter by project is a follow-up
- No project CRUD UI — project nodes are created by `RelationExtractor` from transcripts
- Corpus scope filtering integration is a follow-up
- No settings UI for default project

Fixes #20