### PR TITLE
Fix: harden Electron security — sandbox, CSP, IPC validation, navigation guards (#76)

### DIFF
--- a/electron/ModelSelectorWindowHelper.ts
+++ b/electron/ModelSelectorWindowHelper.ts
@@ -114,6 +114,7 @@ export class ModelSelectorWindowHelper {
             webPreferences: {
                 nodeIntegration: false,
                 contextIsolation: true,
+                sandbox: true,
                 preload: path.join(__dirname, "preload.js"),
                 backgroundThrottling: false
             }

--- a/electron/SettingsWindowHelper.ts
+++ b/electron/SettingsWindowHelper.ts
@@ -139,6 +139,7 @@ export class SettingsWindowHelper {
             webPreferences: {
                 nodeIntegration: false,
                 contextIsolation: true,
+                sandbox: true,
                 preload: path.join(__dirname, "preload.js"),
                 backgroundThrottling: false // Keep window ready even when hidden
             }

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -128,10 +128,10 @@ export class WindowHelper {
       webPreferences: {
         nodeIntegration: false,
         contextIsolation: true,
+        sandbox: true,
         preload: path.join(__dirname, "preload.js"),
         scrollBounce: true,
-        webSecurity: !isDev, // DEBUG: Disable web security only in dev
-        webviewTag: true, // Enable <webview> for Multica panel
+        webSecurity: true,
       },
       show: false, // DEBUG: Force show -> Fixed white screen, now relies on ready-to-show
       titleBarStyle: 'hiddenInset',
@@ -184,6 +184,7 @@ export class WindowHelper {
       webPreferences: {
         nodeIntegration: false,
         contextIsolation: true,
+        sandbox: true,
         preload: path.join(__dirname, "preload.js"),
         scrollBounce: true,
       },

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1407,7 +1407,10 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   safeHandle("open-path", async (_event, filePath: string) => {
-    if (!validateFilePath(filePath)) return;
+    if (!validateFilePath(filePath)) {
+      console.warn(`[IPC] Blocked open-path with invalid file path`);
+      return;
+    }
     await shell.openPath(filePath);
   });
 

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -3,6 +3,7 @@
 import { app, ipcMain, shell, dialog, desktopCapturer, systemPreferences, BrowserWindow, screen } from "electron"
 import { MulticaManager } from "./services/MulticaManager"
 import { AppState } from "./main"
+import { validateFilePath, validateUrl } from './security'
 import { GEMINI_FLASH_MODEL } from "./IntelligenceManager"
 import { DatabaseManager } from "./db/DatabaseManager"; // Import Database Manager
 import * as path from "path";
@@ -84,8 +85,11 @@ export function initializeIpcHandlers(appState: AppState): void {
     return { success: true };
   })
 
-  safeHandle("delete-screenshot", async (event, path: string) => {
-    return appState.deleteScreenshot(path)
+  safeHandle("delete-screenshot", async (event, filePath: string) => {
+    if (!validateFilePath(filePath)) {
+      return { success: false, error: 'Invalid file path' };
+    }
+    return appState.deleteScreenshot(filePath)
   })
 
   safeHandle("take-screenshot", async () => {
@@ -273,9 +277,12 @@ export function initializeIpcHandlers(appState: AppState): void {
   })
 
   // IPC handler for analyzing image from file path
-  safeHandle("analyze-image-file", async (event, path: string) => {
+  safeHandle("analyze-image-file", async (event, filePath: string) => {
+    if (!validateFilePath(filePath)) {
+      throw new Error('Invalid file path');
+    }
     try {
-      const result = await appState.processingHelper.getLLMHelper().analyzeImageFile(path)
+      const result = await appState.processingHelper.getLLMHelper().analyzeImageFile(filePath)
       return result
     } catch (error: any) {
       // console.error("Error in analyze-image-file handler:", error)
@@ -495,6 +502,9 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   safeHandle("switch-to-ollama", async (_, model?: string, url?: string) => {
     try {
+      if (url !== undefined && !validateUrl(url)) {
+        return { success: false, error: 'Invalid URL — only http: and https: allowed' };
+      }
       const llmHelper = appState.processingHelper.getLLMHelper();
       await llmHelper.switchToOllama(model, url);
       return { success: true };
@@ -1397,7 +1407,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   safeHandle("open-path", async (_event, filePath: string) => {
-    if (typeof filePath !== 'string' || !filePath) return;
+    if (!validateFilePath(filePath)) return;
     await shell.openPath(filePath);
   });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, shell } from "electron"
+import { app, BrowserWindow, Tray, Menu, nativeImage, ipcMain, shell, session } from "electron"
 import path from "path"
 import fs from "fs"
 import { autoUpdater } from "electron-updater"
@@ -1857,6 +1857,29 @@ async function initializeApp() {
 
   // Initialize IPC handlers before window creation
   initializeIpcHandlers(appState)
+
+  // Lock down permission requests from renderer
+  session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+    const allowedPermissions = ['clipboard-read', 'clipboard-sanitized-write', 'media'];
+    callback(allowedPermissions.includes(permission));
+  });
+
+  // Prevent navigation to unexpected URLs and handle new window requests
+  app.on('web-contents-created', (_event, contents) => {
+    contents.on('will-navigate', (event, navigationUrl) => {
+      const parsedUrl = new URL(navigationUrl);
+      if (parsedUrl.protocol !== 'file:' && !navigationUrl.startsWith('http://localhost')) {
+        event.preventDefault();
+      }
+    });
+
+    contents.setWindowOpenHandler(({ url }) => {
+      if (url.startsWith('http:') || url.startsWith('https:')) {
+        shell.openExternal(url);
+      }
+      return { action: 'deny' };
+    });
+  });
 
   // Set initial app name — apply disguise name early if configured
   const initialDisguise = appState.getDisguise();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1867,8 +1867,12 @@ async function initializeApp() {
   // Prevent navigation to unexpected URLs and handle new window requests
   app.on('web-contents-created', (_event, contents) => {
     contents.on('will-navigate', (event, navigationUrl) => {
-      const parsedUrl = new URL(navigationUrl);
-      if (parsedUrl.protocol !== 'file:' && !navigationUrl.startsWith('http://localhost')) {
+      try {
+        const parsedUrl = new URL(navigationUrl);
+        if (parsedUrl.protocol !== 'file:' && !navigationUrl.startsWith('http://localhost')) {
+          event.preventDefault();
+        }
+      } catch {
         event.preventDefault();
       }
     });

--- a/electron/security.ts
+++ b/electron/security.ts
@@ -1,0 +1,35 @@
+import path from 'path';
+import { app } from 'electron';
+
+const ALLOWED_DIRS = [
+  () => app.getPath('userData'),
+  () => app.getPath('temp'),
+];
+
+/**
+ * Validate that a file path is within allowed directories.
+ * Prevents path-traversal attacks from renderer-supplied paths.
+ */
+export function validateFilePath(filePath: string): boolean {
+  if (typeof filePath !== 'string' || !filePath.trim()) return false;
+  const resolved = path.resolve(filePath);
+  return ALLOWED_DIRS.some(dirFn => {
+    try {
+      return resolved.startsWith(dirFn() + path.sep) || resolved === dirFn();
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Validate a URL against an allowlist of protocols.
+ */
+export function validateUrl(url: string, allowedProtocols = ['http:', 'https:']): boolean {
+  try {
+    const parsed = new URL(url);
+    return allowedProtocols.includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <title>Natively</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; img-src 'self' data: https:; connect-src 'self' https://generativelanguage.googleapis.com https://api.groq.com https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;">
+    content="default-src 'self'; script-src 'self' https://www.googletagmanager.com; img-src 'self' data: https:; connect-src 'self' https://generativelanguage.googleapis.com https://api.groq.com https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;">
 </head>
 
 <body style="background-color: #000000; margin: 0; overflow: hidden;">

--- a/test/electron/security.test.ts
+++ b/test/electron/security.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock electron app before importing
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((name: string) => {
+      if (name === 'userData') return '/mock/userData';
+      if (name === 'temp') return '/mock/temp';
+      return '/mock/other';
+    }),
+  },
+}));
+
+import { validateFilePath, validateUrl } from '../../electron/security';
+
+describe('validateFilePath', () => {
+  it('allows paths within userData', () => {
+    expect(validateFilePath('/mock/userData/screenshots/img.png')).toBe(true);
+  });
+
+  it('allows paths within temp', () => {
+    expect(validateFilePath('/mock/temp/file.tmp')).toBe(true);
+  });
+
+  it('rejects paths outside allowed directories', () => {
+    expect(validateFilePath('/etc/passwd')).toBe(false);
+    expect(validateFilePath('/home/user/.ssh/id_rsa')).toBe(false);
+  });
+
+  it('rejects path traversal attempts', () => {
+    expect(validateFilePath('/mock/userData/../../../etc/passwd')).toBe(false);
+    expect(validateFilePath('/mock/userData/screenshots/../../..')).toBe(false);
+  });
+
+  it('rejects empty or non-string input', () => {
+    expect(validateFilePath('')).toBe(false);
+    expect(validateFilePath('   ')).toBe(false);
+    expect(validateFilePath(null as any)).toBe(false);
+    expect(validateFilePath(undefined as any)).toBe(false);
+  });
+});
+
+describe('validateUrl', () => {
+  it('allows http and https URLs', () => {
+    expect(validateUrl('https://example.com')).toBe(true);
+    expect(validateUrl('http://localhost:11434')).toBe(true);
+  });
+
+  it('rejects file: and other protocols', () => {
+    expect(validateUrl('file:///etc/passwd')).toBe(false);
+    expect(validateUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(validateUrl('not a url')).toBe(false);
+    expect(validateUrl('')).toBe(false);
+  });
+});

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,10 +1,27 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+// Dev-only: the production CSP in index.html uses a strict `script-src 'self'`
+// (no 'unsafe-inline'), but @vitejs/plugin-react injects an inline React-refresh
+// preamble during `vite serve`. Relax script-src to allow that inline script in
+// dev only; the built index.html keeps the strict policy untouched.
+function devCspRelax(): Plugin {
+    return {
+        name: 'dev-csp-relax',
+        apply: 'serve',
+        transformIndexHtml(html) {
+            return html.replace(
+                "script-src 'self' https://www.googletagmanager.com",
+                "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com"
+            )
+        },
+    }
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react()],
+    plugins: [react(), devCspRelax()],
     base: './', // Use relative paths for Electron
     resolve: {
         alias: {


### PR DESCRIPTION
## Summary

Hardens Electron security posture against best-practice templates (secure-electron-template, vite-electron-builder). Addresses path-traversal vulnerabilities in IPC handlers, missing sandbox enforcement, overly permissive CSP, and absent permission/navigation guards.

Fixes #76

## Root Cause

The app had several long-standing security gaps from initial development:
- **Path-traversal vulnerabilities**: `deleteScreenshot` and `analyzeImageFile` IPC handlers accepted arbitrary file paths from the renderer without validation, allowing file deletion/read of any file on disk
- **Missing sandbox**: No `sandbox: true` on any BrowserWindow
- **Weak CSP**: `'unsafe-inline'` in `script-src` weakened XSS protection
- **Unused webviewTag**: Enabled but never used, expanding attack surface
- **webSecurity disabled in dev**: `webSecurity: !isDev` bypassed same-origin policy during development
- **No permission handler**: Renderer could request any Electron permission
- **No navigation guard**: No protection against unexpected URL navigation

## Changes

| File | Change |
|------|--------|
| `electron/security.ts` | **NEW** — Shared `validateFilePath` and `validateUrl` utilities |
| `electron/WindowHelper.ts` | Add `sandbox: true`, remove `webviewTag`, enforce `webSecurity: true` |
| `electron/SettingsWindowHelper.ts` | Add `sandbox: true` |
| `electron/ModelSelectorWindowHelper.ts` | Add `sandbox: true` |
| `electron/ipcHandlers.ts` | Path validation on `delete-screenshot`, `analyze-image-file`, `open-path`; URL validation on `switch-to-ollama` |
| `electron/main.ts` | `setPermissionRequestHandler`, `will-navigate` guard, `setWindowOpenHandler` |
| `index.html` | Remove `'unsafe-inline'` from `script-src` in CSP |
| `test/electron/security.test.ts` | **NEW** — 8 tests for path and URL validation |

## Validation

| Check | Result |
|-------|--------|
| TypeScript (`tsc --noEmit`) | Pass |
| Tests (`vitest run test/electron/security.test.ts`) | 8/8 passed |

## Risk Assessment

- **`sandbox: true`**: `better-sqlite3` runs in main process, not renderer — no impact expected
- **CSP `unsafe-inline` removal**: Only removed from `script-src`; kept in `style-src` for CSS-in-JS. Vite bundles scripts in production builds, so no breakage expected. Test GTM if analytics is active.
- **`webSecurity: true` in dev**: Vite dev server handles CORS via proxy; configure Vite proxy if CORS issues arise
