### PR TITLE
fix: add per-window try-catch in broadcast() to prevent cascade failure

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -114,6 +114,18 @@ import { getAgentConfig, setAgentIntervalMs } from "./config/agentConfig"
 
 function mt(fr: string, en: string): string { return getUiLang() === 'fr' ? fr : en; }
 
+export function broadcastToWindows(channel: string, ...args: any[]): void {
+  BrowserWindow.getAllWindows().forEach(win => {
+    try {
+      if (!win.isDestroyed()) {
+        win.webContents.send(channel, ...args);
+      }
+    } catch (err) {
+      console.error(`[broadcast] failed to send '${channel}' to window ${win.id}:`, err);
+    }
+  });
+}
+
 export class AppState {
   private static instance: AppState | null = null
 
@@ -301,15 +313,7 @@ export class AppState {
   }
 
   private broadcast(channel: string, ...args: any[]): void {
-    BrowserWindow.getAllWindows().forEach(win => {
-      try {
-        if (!win.isDestroyed() && win.webContents) {
-          win.webContents.send(channel, ...args);
-        }
-      } catch (e) {
-        console.error(`[broadcast] failed to send '${channel}' to window ${win.id}:`, e);
-      }
-    });
+    broadcastToWindows(channel, ...args);
   }
 
   private initializeRAGManager(): void {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -302,8 +302,12 @@ export class AppState {
 
   private broadcast(channel: string, ...args: any[]): void {
     BrowserWindow.getAllWindows().forEach(win => {
-      if (!win.isDestroyed()) {
-        win.webContents.send(channel, ...args);
+      try {
+        if (!win.isDestroyed() && win.webContents) {
+          win.webContents.send(channel, ...args);
+        }
+      } catch (e) {
+        console.error(`[broadcast] failed to send '${channel}' to window ${win.id}:`, e);
       }
     });
   }

--- a/test/electron/broadcast.test.ts
+++ b/test/electron/broadcast.test.ts
@@ -18,6 +18,7 @@ vi.mock('electron', () => {
 });
 
 import { BrowserWindow } from 'electron';
+import { broadcastToWindows } from '../../electron/main';
 
 function makeMockWin(opts: { destroyed?: boolean; throws?: boolean; id?: number } = {}) {
   const send = opts.throws
@@ -30,20 +31,7 @@ function makeMockWin(opts: { destroyed?: boolean; throws?: boolean; id?: number 
   };
 }
 
-// Extract the broadcast logic to test in isolation
-function broadcast(channel: string, ...args: any[]): void {
-  (BrowserWindow.getAllWindows() as any[]).forEach((win: any) => {
-    try {
-      if (!win.isDestroyed() && win.webContents) {
-        win.webContents.send(channel, ...args);
-      }
-    } catch (e) {
-      console.error(`[broadcast] failed to send '${channel}' to window ${win.id}:`, e);
-    }
-  });
-}
-
-describe('broadcast()', () => {
+describe('broadcastToWindows()', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -53,7 +41,7 @@ describe('broadcast()', () => {
     const win2 = makeMockWin({ id: 2 });
     (BrowserWindow.getAllWindows as any).mockReturnValue([win1, win2]);
 
-    broadcast('test:event', { data: 42 });
+    broadcastToWindows('test:event', { data: 42 });
 
     expect(win1.webContents.send).toHaveBeenCalledWith('test:event', { data: 42 });
     expect(win2.webContents.send).toHaveBeenCalledWith('test:event', { data: 42 });
@@ -64,7 +52,7 @@ describe('broadcast()', () => {
     const alive = makeMockWin({ id: 2 });
     (BrowserWindow.getAllWindows as any).mockReturnValue([destroyed, alive]);
 
-    broadcast('test:event');
+    broadcastToWindows('test:event');
 
     expect(destroyed.webContents.send).not.toHaveBeenCalled();
     expect(alive.webContents.send).toHaveBeenCalledWith('test:event');
@@ -77,7 +65,7 @@ describe('broadcast()', () => {
 
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(() => broadcast('approval:draft')).not.toThrow();
+    expect(() => broadcastToWindows('approval:draft')).not.toThrow();
     expect(good.webContents.send).toHaveBeenCalledWith('approval:draft');
     expect(errSpy).toHaveBeenCalledWith(
       expect.stringContaining('[broadcast]'),
@@ -85,5 +73,10 @@ describe('broadcast()', () => {
     );
 
     errSpy.mockRestore();
+  });
+
+  it('does nothing when no windows are open', () => {
+    (BrowserWindow.getAllWindows as any).mockReturnValue([]);
+    expect(() => broadcastToWindows('test:event')).not.toThrow();
   });
 });

--- a/test/electron/broadcast.test.ts
+++ b/test/electron/broadcast.test.ts
@@ -1,21 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('electron', () => {
-  const mockWindows: any[] = [];
-  return {
-    app: { getPath: () => '/tmp', on: () => {}, whenReady: () => Promise.resolve() },
-    BrowserWindow: {
-      getAllWindows: vi.fn(() => mockWindows),
-      _mockWindows: mockWindows,
-    },
-    ipcMain: { handle: () => {}, on: () => {} },
-    shell: {},
-    nativeImage: { createFromPath: () => ({ resize: () => ({}) }) },
-    Menu: { buildFromTemplate: () => ({}) },
-    Tray: class {},
-    desktopCapturer: { getSources: async () => [] },
-  };
-});
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp', on: () => {}, whenReady: () => Promise.resolve() },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  ipcMain: { handle: () => {}, on: () => {} },
+  shell: {},
+  nativeImage: { createFromPath: () => ({ resize: () => ({}) }) },
+  Menu: { buildFromTemplate: () => ({}) },
+  Tray: class {},
+  desktopCapturer: { getSources: async () => [] },
+}));
 
 import { BrowserWindow } from 'electron';
 import { broadcastToWindows } from '../../electron/main';

--- a/test/electron/broadcast.test.ts
+++ b/test/electron/broadcast.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => {
+  const mockWindows: any[] = [];
+  return {
+    app: { getPath: () => '/tmp', on: () => {}, whenReady: () => Promise.resolve() },
+    BrowserWindow: {
+      getAllWindows: vi.fn(() => mockWindows),
+      _mockWindows: mockWindows,
+    },
+    ipcMain: { handle: () => {}, on: () => {} },
+    shell: {},
+    nativeImage: { createFromPath: () => ({ resize: () => ({}) }) },
+    Menu: { buildFromTemplate: () => ({}) },
+    Tray: class {},
+    desktopCapturer: { getSources: async () => [] },
+  };
+});
+
+import { BrowserWindow } from 'electron';
+
+function makeMockWin(opts: { destroyed?: boolean; throws?: boolean; id?: number } = {}) {
+  const send = opts.throws
+    ? vi.fn(() => { throw new Error('renderer gone'); })
+    : vi.fn();
+  return {
+    id: opts.id ?? 1,
+    isDestroyed: vi.fn(() => opts.destroyed ?? false),
+    webContents: { send },
+  };
+}
+
+// Extract the broadcast logic to test in isolation
+function broadcast(channel: string, ...args: any[]): void {
+  (BrowserWindow.getAllWindows() as any[]).forEach((win: any) => {
+    try {
+      if (!win.isDestroyed() && win.webContents) {
+        win.webContents.send(channel, ...args);
+      }
+    } catch (e) {
+      console.error(`[broadcast] failed to send '${channel}' to window ${win.id}:`, e);
+    }
+  });
+}
+
+describe('broadcast()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends to all live windows', () => {
+    const win1 = makeMockWin({ id: 1 });
+    const win2 = makeMockWin({ id: 2 });
+    (BrowserWindow.getAllWindows as any).mockReturnValue([win1, win2]);
+
+    broadcast('test:event', { data: 42 });
+
+    expect(win1.webContents.send).toHaveBeenCalledWith('test:event', { data: 42 });
+    expect(win2.webContents.send).toHaveBeenCalledWith('test:event', { data: 42 });
+  });
+
+  it('skips destroyed windows', () => {
+    const destroyed = makeMockWin({ destroyed: true, id: 1 });
+    const alive = makeMockWin({ id: 2 });
+    (BrowserWindow.getAllWindows as any).mockReturnValue([destroyed, alive]);
+
+    broadcast('test:event');
+
+    expect(destroyed.webContents.send).not.toHaveBeenCalled();
+    expect(alive.webContents.send).toHaveBeenCalledWith('test:event');
+  });
+
+  it('continues broadcasting to remaining windows when one send() throws', () => {
+    const bad = makeMockWin({ throws: true, id: 1 });
+    const good = makeMockWin({ id: 2 });
+    (BrowserWindow.getAllWindows as any).mockReturnValue([bad, good]);
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => broadcast('approval:draft')).not.toThrow();
+    expect(good.webContents.send).toHaveBeenCalledWith('approval:draft');
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[broadcast]'),
+      expect.any(Error),
+    );
+
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- `AppState.broadcast()` in `electron/main.ts` lacked a per-window try-catch around `win.webContents.send()`, causing a TOCTOU race: a window entering teardown *after* `isDestroyed()` returned `false` but *before* `.send()` executed would throw, aborting the entire `forEach` loop and silently dropping the IPC message to all remaining windows.
- Added a per-window `try/catch` and a `win.webContents` null-guard so a single failing window is logged and skipped; the rest of the broadcast continues.
- Added a dedicated unit test (`test/electron/broadcast.test.ts`) covering: all-live delivery, destroyed-window skip, and continued delivery when one `.send()` throws mid-loop.

## Changes

### `electron/main.ts` (+9 / -2)

Replaced the bare `isDestroyed()` guard in `broadcast()` (lines 303-309) with a try-catch that logs the error per-window and continues:

```typescript
// Before
private broadcast(channel: string, ...args: any[]): void {
  BrowserWindow.getAllWindows().forEach(win => {
    if (!win.isDestroyed()) {
      win.webContents.send(channel, ...args);
    }
  });
}

// After
private broadcast(channel: string, ...args: any[]): void {
  BrowserWindow.getAllWindows().forEach(win => {
    try {
      if (!win.isDestroyed() && win.webContents) {
        win.webContents.send(channel, ...args);
      }
    } catch (e) {
      console.error(`[broadcast] failed to send '${channel}' to window ${win.id}:`, e);
    }
  });
}
```

### `test/electron/broadcast.test.ts` (new, +88 lines)

Three test cases exercising the fixed `broadcast()` logic in isolation via mocked `BrowserWindow.getAllWindows()`:

1. Sends to all live windows
2. Skips destroyed windows without error
3. Continues to remaining windows when one `.send()` throws (the key regression test)

## Validation

| Check | Result |
|-------|--------|
| `tsc -p electron/tsconfig.json --noEmit` | ✅ Pass |
| `tsc --noEmit` (src) | ✅ Pass |
| `vitest run test/electron/broadcast.test.ts` | ✅ 3/3 passed |
| `npm run build` | ✅ Pass |
| Full suite (`vitest run`) | ⚠️ 300 pass / 240 pre-existing failures (better-sqlite3 ABI mismatch — Electron vs Node rebuild; unrelated to this change) |

## Root Cause

The `isDestroyed()` guard (added in #77) was a partial fix. `.send()` can still throw when a window transitions to destroyed state in the microseconds between the guard check and the send call. The try-catch is the correct Electron idiom for this race.

Fixes #84
