### PR TITLE
fix: validate NODE_KINDS enum in RelationExtractor

### DIFF
--- a/electron/memory/RelationExtractor.ts
+++ b/electron/memory/RelationExtractor.ts
@@ -22,6 +22,7 @@ export type LLMFn = (systemPrompt: string, userText: string) => Promise<string>;
 
 // Derived from NODE_KINDS — add new node types in schema.ts, this updates automatically.
 const KIND_LIST = NODE_KINDS.map(k => `"${k}"`).join(', ');
+const VALID_KINDS = new Set<string>(NODE_KINDS);
 
 const EXTRACTION_SYSTEM_PROMPT = `You are a relation extractor for a personal knowledge graph.
 Given a transcript snippet, extract structured triples (subject → predicate → object).
@@ -72,16 +73,18 @@ export async function extractRelations(
   for (const p of proposals) {
     if (!p.sourceLabel || !p.targetLabel || !p.predicate) continue;
     if (typeof p.confidence !== 'number' || p.confidence < 0 || p.confidence > 1) continue;
+    if (!VALID_KINDS.has(p.sourceKind)) {
+      console.warn(`[RelationExtractor] unknown sourceKind '${p.sourceKind}' — skipping`);
+      continue;
+    }
+    if (!VALID_KINDS.has(p.targetKind)) {
+      console.warn(`[RelationExtractor] unknown targetKind '${p.targetKind}' — skipping`);
+      continue;
+    }
 
     // Ensure nodes exist
-    const source = memoryManager.upsertNode(
-      p.sourceKind || 'topic',
-      p.sourceLabel,
-    );
-    const target = memoryManager.upsertNode(
-      p.targetKind || 'topic',
-      p.targetLabel,
-    );
+    const source = memoryManager.upsertNode(p.sourceKind, p.sourceLabel);
+    const target = memoryManager.upsertNode(p.targetKind, p.targetLabel);
 
     // Confidence-gated: goes to edges or pending_review
     memoryManager.proposeEdge(

--- a/test/memory/RelationExtractor.test.ts
+++ b/test/memory/RelationExtractor.test.ts
@@ -112,4 +112,40 @@ describe('extractRelations', () => {
     const result = await extractRelations('test', null, llm, mm);
     expect(result.length).toBe(0);
   });
+
+  it('skips proposals with an unrecognized sourceKind', async () => {
+    const llm = stubLLM([
+      {
+        sourceKind: 'Person' as any,  // wrong case — not in NODE_KINDS
+        sourceLabel: 'Alice',
+        targetKind: 'person',
+        targetLabel: 'Bob',
+        predicate: 'knows',
+        confidence: 0.9,
+        context: 'test',
+      },
+    ]);
+
+    const result = await extractRelations('test', null, llm, mm);
+    expect(result.length).toBe(0);
+    expect(mm.findNodes('person').length).toBe(0);
+  });
+
+  it('skips proposals with an unrecognized targetKind', async () => {
+    const llm = stubLLM([
+      {
+        sourceKind: 'person',
+        sourceLabel: 'Alice',
+        targetKind: 'task' as any,  // invented kind not in NODE_KINDS
+        targetLabel: 'Fix bug',
+        predicate: 'works_on',
+        confidence: 0.8,
+        context: 'test',
+      },
+    ]);
+
+    const result = await extractRelations('test', null, llm, mm);
+    expect(result.length).toBe(0);
+    expect(mm.findNodes('person').length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- `RelationExtractor.extractRelations()` built a `KIND_LIST` from `NODE_KINDS` for the LLM prompt but never validated the LLM's returned `sourceKind`/`targetKind` against that same set at runtime — hallucinated kinds (e.g. `'Person'` instead of `'person'`, `'task'` instead of `'ActionItem'`) silently entered the SQLite memory graph
- Added a `VALID_KINDS = new Set(NODE_KINDS)` constant (computed once at module load) and two guard checks in the for-loop that skip and warn on any unrecognized kind
- Removed the `|| 'topic'` fallback from `upsertNode` calls — it masked the bug by silently downgrading invalid kinds rather than rejecting them
- Added 2 regression tests covering unrecognized `sourceKind` and `targetKind`

## Changes

| File | Action |
|------|--------|
| `electron/memory/RelationExtractor.ts` | +11/-7 — add `VALID_KINDS` Set; add kind guards; remove `\|\| 'topic'` fallback |
| `test/memory/RelationExtractor.test.ts` | +36/-1 — two new tests: invalid sourceKind skipped, invalid targetKind skipped |

## Validation

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | ✅ 0 errors |
| `npx tsc -p electron/tsconfig.json --noEmit` | ✅ 0 errors |
| `npx vitest run test/memory/RelationExtractor.test.ts` | ✅ 7 passed (5 existing + 2 new) |
| `npx vitest run` (full suite) | ✅ 539 passed, 0 failed (95 files) |

## Root Cause

`NODE_KINDS` was already imported and used to build the prompt but was never consulted at parse time. The truthy fallback `p.sourceKind || 'topic'` only caught `undefined`/`null`/empty-string — a non-empty invalid string like `'Person'` or `'task'` passed straight through to `upsertNode`, creating a node with an unrecognized kind. `GoalAligner` and `DecisionQuery` filter by kind, so those nodes were silently excluded from queries.

## Edge Cases

- `p.sourceKind` is `undefined` → `VALID_KINDS.has(undefined)` returns `false` → skipped (correct)
- Adding a new entry to `NODE_KINDS` in `schema.ts` automatically allows it in `VALID_KINDS` — no code change needed
- Out of scope: backfilling existing invalid nodes in the DB (separate migration concern)

Fixes #86
